### PR TITLE
heat_map_analysis update to allow selecting misclassified images and images by id or filename

### DIFF
--- a/dlpy/images.py
+++ b/dlpy/images.py
@@ -139,7 +139,7 @@ class ImageTable(CASTable):
                       table=table_opts,
                       casout=dict(replace=True, blocksize=32, **casout))
 
-        column_names = ['_image_', '_label_', '_filename_0']
+        column_names = ['_image_', '_label_', '_filename_0', '_id_']
         if columns is not None:
             if not isinstance(columns, list):
                 columns = list(columns)
@@ -199,7 +199,7 @@ class ImageTable(CASTable):
         code.append('_loc1 = LENGTH(_path_) - INDEX(REVERSE(_path_),\'/\')+2;')
         code.append('_filename_0 = SUBSTR(_path_,_loc1);')
         code = '\n'.join(code)
-        column_names = ['_image_', '_label_', '_filename_0']
+        column_names = ['_image_', '_label_', '_filename_0', '_id_']
         if columns is not None:
             column_names += columns
         conn.retrieve('table.partition', _messagelevel='error',


### PR DESCRIPTION
I used some changes from Alex pull request and combined with my own. 

heat_map_analysis has the following additional features:

- set img_type to 'A', 'M' or 'C' to get all, misclassified or correctly classified images respectively
-pass a list of _id_ ' s or a singing _id_ value to image_id to run heatmap on specific images
- pass a list of filenames or a single filename to get heatmaps on the images containing that filename
  image_id is unique while filename is not thus image_id overrides filename if both are passed into the function
- can also display more or less than 5 images by setting max_display

Additionally:
-_id_ was added to the ImageTable
-the model.py attributes documentation was updated
-An attribute valid_res_tbl was added so that the results from predict() can be further analized without bringing to the client
-_id_ column was added to valid_res SASDataFrame output
