### PR TITLE
Add graph transformations for importing ONNX models

### DIFF
--- a/dlpy/model_conversion/onnx_graph.py
+++ b/dlpy/model_conversion/onnx_graph.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+''' Helpers for ONNX graph and node protobufs '''
+
+import onnx
+from onnx import helper, numpy_helper, mapping
+from onnx import NodeProto
+
+
+def _convert_onnx_attribute_proto(attr_proto):
+    '''
+    Convert ONNX AttributeProto into Python object
+    '''
+    if attr_proto.HasField('f'):
+        return attr_proto.f
+    elif attr_proto.HasField('i'):
+        return attr_proto.i
+    elif attr_proto.HasField('s'):
+        return str(attr_proto.s, 'utf-8')
+    elif attr_proto.HasField('t'):
+        return attr_proto.t  # this is a proto!
+    elif attr_proto.floats:
+        return list(attr_proto.floats)
+    elif attr_proto.ints:
+        return list(attr_proto.ints)
+    elif attr_proto.strings:
+        str_list = list(attr_proto.strings)
+        str_list = list(map(lambda x: str(x, 'utf-8'), str_list))
+        return str_list
+    else:
+        raise ValueError("Unsupported ONNX attribute: {}".format(attr_proto))    
+
+
+class OnnxNode(object):
+    ''' 
+    Reimplementation of NodeProto from ONNX, but in a form
+    more convenient to work with from Python.
+    ''' 
+
+    def __init__(self, node):
+        self.name = str(node.name)
+        self.op_type = str(node.op_type)
+        self.domain = str(node.domain)
+        self.attrs = dict([(attr.name,
+                            _convert_onnx_attribute_proto(attr))
+                           for attr in node.attribute])
+        self.input = list(node.input)
+        self.output = list(node.output)
+        self.node_proto = node
+        self.parents = []
+        self.children = []
+        self.tensors = {}
+
+    def add_child(self, child):
+        if not isinstance(child, (tuple, list)):
+            child = [child]
+        child = list(filter(lambda x: x not in self.children, child))
+        self.children.extend(child)
+        
+        for c in child:
+            if self not in c.parents:
+                c.add_parent(self)
+
+    def add_parent(self, parent):
+        if not isinstance(parent, (tuple, list)):
+            parent = [parent]
+        parent = list(filter(lambda x: x not in self.parents, parent))
+        self.parents.extend(parent)
+
+        for p in parent:
+            if self not in p.children:
+                p.add_child(self)
+
+
+class OnnxGraph(object):
+    '''
+    Helper class for holding ONNX graph
+    '''
+    def __init__(self, graph_def):
+        self.name = graph_def.name
+        self.node = [OnnxNode(n) for n in graph_def.node]
+        self.value_info = list(graph_def.value_info)
+        self.input = list(graph_def.input)
+        self.output = list(graph_def.output)
+        self.initializer = list(graph_def.initializer)
+        self.tensor_dict = dict([(init.name, numpy_helper.to_array(init))
+                                  for init in graph_def.initializer])
+        self.uninitialized = [i for i in graph_def.input
+                              if i.name not in self.tensor_dict]
+    
+    def get_node(self, name):
+        for n in self.node:
+            if n.name == name:
+                return n
+        return None
+
+    def get_node_index(self, name):
+        for idx, n in enumerate(self.node):
+            if n.name == name:
+                return idx
+        return None
+    
+    def remove_node(self, name):
+        self.node = list(filter(lambda x: x.name != name, self.node))
+        self.connect_nodes()
+
+    def replace_node(self, name, node):
+        idx = self.get_node_index(name)
+        if idx is not None:
+            self.node[idx] = node
+        self.connect_nodes()
+    
+    def insert_node(self, name, node):
+        idx = self.get_node_index(name)
+        if idx is not None:
+            self.node.insert(idx+1, node)
+        self.connect_nodes()
+    
+    def get_input(self, name):
+        for i in self.input:
+            if i.name == name:
+                return i
+        return None
+
+    def add_input(self, value_info):
+        if not isinstance(value_info, (list, tuple)):
+            value_info = [value_info] 
+        self.input.extend(value_info)
+
+    def replace_input(self, name, value_info):
+        for idx, proto in enumerate(self.input):
+            if proto.name == name:
+                self.input[idx] = value_info
+
+    def get_initializer(self, name):
+        for i in self.initializer:
+            if i.name == name:
+                return i
+        return None
+
+    def add_initializer(self, init):
+        if not isinstance(init, (list, tuple)):
+            init = [init]
+        self.initializer.extend(init)
+
+    def replace_initializer(self, name, init):
+        for idx, proto in enumerate(self.initializer):
+            if proto.name == name:
+                self.initializer[idx] = init
+
+    def clean_init(self):
+        all_inputs = [i for n in self.node for i in n.input]
+        self.input = list(filter(lambda x: x.name in all_inputs,
+                                 self.input))
+        self.initializer = list(filter(lambda x: x.name in all_inputs,
+                                       self.initializer))
+        self.tensor_dict = {k:v for k,v in self.tensor_dict.items()
+                                if k in all_inputs}
+
+    def connect_nodes(self):
+        # mapping from input to nodes
+        input_to_node = {}
+        for node in self.node:
+            # reset any existing links
+            node.parents = []
+            node.children = []
+            for input_ in node.input:
+                if input_to_node.get(input_) is None:
+                    input_to_node[input_] = []
+                if node not in input_to_node[input_]:
+                    input_to_node[input_].append(node)
+
+        for node in self.node:
+            for output_ in node.output:
+                if not input_to_node.get(output_):
+                    continue
+                node.add_child(input_to_node[output_])
+    
+    def make_onnx(self):
+        self.clean_init()
+        nodes = []
+        for node in self.node:
+            n = NodeProto()
+            n.input.extend(node.input)
+            n.output.extend(node.output)
+            n.name = node.name
+            n.op_type = node.op_type
+            n.attribute.extend(
+                helper.make_attribute(key, value)
+                for key, value in sorted(node.attrs.items())
+                )
+            nodes.append(n)
+        
+        inputs = []
+        initializer = []
+        for k,v in self.tensor_dict.items():
+            init = numpy_helper.from_array(v, name=k)
+            initializer.append(init)
+            value_info = helper.make_tensor_value_info(
+                name=k,
+                elem_type=mapping.NP_TYPE_TO_TENSOR_TYPE[v.dtype],
+                shape=list(v.shape)
+            )
+            inputs.append(value_info)
+        
+        graph_ = helper.make_graph(
+            nodes=nodes,
+            name='dlpy_graph',
+            inputs=inputs+self.uninitialized,
+            outputs=self.output,
+            initializer=initializer
+        )
+
+        model = helper.make_model(graph_)
+        return model
+
+    @classmethod
+    def from_onnx(cls, graph):
+        graph_ = cls(graph)
+        for idx, node in enumerate(graph_.node):
+            if not node.name:
+                node.name = '{}_{}'.format(node.op_type, idx)
+            elif '/' in node.name:
+                node.name.replace('/', '_')
+        graph_.connect_nodes()
+        # add initialized tensors to nodes
+        for node in graph_.node:
+            for input_ in node.input:
+                if input_ in graph_.tensor_dict:
+                    node.tensors[input_] = graph_.tensor_dict[input_]
+        return graph_
+

--- a/dlpy/model_conversion/onnx_transforms.py
+++ b/dlpy/model_conversion/onnx_transforms.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+''' Transforms for ONNX graph '''
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper, shape_inference, mapping
+from onnx import AttributeProto, TensorProto, GraphProto
+
+from dlpy.model_conversion.onnx_graph import OnnxNode
+
+
+class OpTypePattern(object):
+    def __init__(self, op_type, name=None, outputs=None):
+        self._op_type = op_type
+        self._name = name
+        if outputs is None:
+            outputs = []
+        self._outputs = [
+            output_pattern if isinstance(output_pattern, OpTypePattern) else
+            OpTypePattern(output_pattern) for output_pattern in outputs
+        ]
+    
+    @property
+    def op_type(self):
+        return self._op_type
+    
+    @property
+    def outputs(self):
+        return self._outputs
+    
+    @property
+    def name(self):
+        return self._name
+
+    
+class Transformer(object):
+    def __init__(self, pattern=None):
+        self.pattern = pattern
+
+    def match(self, node, pattern=None):
+        if pattern is None:
+            if self.pattern is None:
+                raise ValueError('No pattern to match.')
+            pattern = self.pattern
+
+        if node.op_type != pattern.op_type:
+            return False
+        elif pattern.outputs and len(node.children) != len(pattern.outputs):
+            return False
+        else:
+            ret = []
+            for child, child_pattern in zip(node.children, pattern.outputs):
+                r = self.match(child, child_pattern)
+                ret.append(r)
+            return all(ret)
+
+    def get_mapping(self, node, pattern=None):
+        if pattern is None:
+            if self.pattern is None:
+                raise ValueError('No pattern to match.')
+            pattern = self.pattern
+        
+        mapping_dict = {}
+        def _mapping(node, pattern, mapping_dict):
+            if pattern.name is None:
+                raise ValueError('Cannot generate mapping dict,'
+                                ' OpTypePattern name is None.')
+            mapping_dict[pattern.name] = node
+            for child, child_pattern in zip(node.children, pattern.outputs):
+                _mapping(child, child_pattern, mapping_dict)
+            return mapping_dict
+        
+        return _mapping(node, pattern, mapping_dict)
+
+    def is_eligible(self, graph, node):
+        return True
+
+    def run_transform(self, graph, node):
+        return graph
+    
+    def __call__(self, graph):
+        matches = filter(lambda x: self.match(x), graph.node)
+        ops = filter(lambda x: self.is_eligible(graph, x), matches)
+        for op in ops:
+            self.run_transform(graph, op)
+            graph.connect_nodes()
+        return graph
+
+
+class ConstToInitializer(Transformer):
+    ''' Remove constant ops '''
+    def __init__(self):
+        pattern = OpTypePattern('Constant')
+        super(ConstToInitializer, self).__init__(pattern)
+    
+    def run_transform(self, graph, node):
+        tensor = numpy_helper.to_array(node.attrs['value'])
+        graph.tensor_dict[node.output[0]] = tensor
+
+        # remove the constant op
+        graph.remove_node(node.name)
+        
+        return graph
+
+
+class InitReshape(Transformer):
+    ''' Remove reshape ops '''
+    def __init__(self):
+        pattern = OpTypePattern('Reshape')
+        super(InitReshape, self).__init__(pattern)
+    
+    def is_eligible(self, graph, node):
+        if node.input[0] in graph.tensor_dict:
+            return True
+        return False
+    
+    def _get_shape(self, graph, node):
+        ''' Get reshape op's shape '''
+        name = node.input[1]
+        shape = [int(x) for x in graph.tensor_dict[name].flatten()]
+        return tuple(shape)
+
+    def run_transform(self, graph, node):
+        shape = self._get_shape(graph, node)
+        tensor = graph.tensor_dict[node.input[0]]
+        graph.tensor_dict[node.output[0]] = tensor.reshape(shape)
+
+        # remove reshape op
+        graph.remove_node(node.name)
+
+        return graph
+
+
+class InitUnsqueeze(Transformer):
+    ''' Remove unsqueeze ops '''
+    def __init__(self):
+        pattern = OpTypePattern('Unsqueeze')
+        super(InitUnsqueeze, self).__init__(pattern)
+    
+    def is_eligible(self, graph, node):
+        if node.input[0] in graph.tensor_dict:
+            return True
+        return False
+    
+    def _unsqueeze(self, tensor, axes):
+        _shape = list(tensor.shape)
+        new_dim = len(tensor.shape) + len(axes)
+        unsqueezed_shape = [1] * new_dim 
+        for i in range(new_dim):
+            if i not in axes:
+                unsqueezed_shape[i] = _shape.pop(0) 
+
+        return tensor.reshape(tuple(unsqueezed_shape))
+
+    def run_transform(self, graph, node):
+        axes = node.attrs['axes']
+        tensor = graph.tensor_dict[node.input[0]]
+        graph.tensor_dict[node.output[0]] = self._unsqueeze(tensor, axes)
+
+        # remove unsqueeze op
+        graph.remove_node(node.name)
+
+        return graph
+
+
+class FuseMulAddBN(Transformer):
+    ''' Fuse Mul + Add into BN '''
+    def __init__(self):
+        add = OpTypePattern('Add', name='add')
+        mul = OpTypePattern('Mul', name='mul', outputs=[add])
+        bn = OpTypePattern('BatchNormalization', name='bn', outputs=[mul])
+        super(FuseMulAddBN, self).__init__(bn)
+
+    def is_eligible(self, graph, node):
+        mapping = self.get_mapping(node)
+        bn, mul, add = mapping['bn'], mapping['mul'], mapping['add']
+
+        if bn.attrs.get('spatial') is not None and bn.attrs['spatial'] != 1:
+            return False
+        if (mul.input[0] not in graph.tensor_dict and
+            mul.input[1] not in graph.tensor_dict):
+            return False
+        if (add.input[0] not in graph.tensor_dict and
+            add.input[1] not in graph.tensor_dict):
+            return False
+
+        t = graph.tensor_dict
+        scale = t[bn.input[1]]
+        bias = t[bn.input[2]]
+        _mul_tensor = t.get(mul.input[0], t[mul.input[1]])
+        mul_tensor = np.squeeze(_mul_tensor)
+        _add_tensor = t.get(add.input[0], t[add.input[1]])
+        add_tensor = np.squeeze(_add_tensor)
+
+        if mul_tensor.shape != scale.shape or mul_tensor.shape != bias.shape:
+            if mul_tensor.shape != (1,) and mul_tensor.shape != ():
+                return False
+        
+        if add_tensor.shape != bias.shape:
+            if add_tensor.shape != (1,) and add_tensor.shape != ():
+                return False
+        
+        return True
+    
+    def run_transform(self, graph, node):
+        mapping = self.get_mapping(node)
+        bn, mul, add = mapping['bn'], mapping['mul'], mapping['add']
+
+        t = graph.tensor_dict
+        scale = t[bn.input[1]]
+        bias = t[bn.input[2]]
+        _mul_tensor = t.get(mul.input[0], t[mul.input[1]])
+        mul_tensor = np.squeeze(_mul_tensor)
+        _add_tensor = t.get(add.input[0], t[add.input[1]])
+        add_tensor = np.squeeze(_add_tensor)
+
+        # multiply scale and bias
+        t[bn.input[1]] = np.multiply(scale, mul_tensor)
+        _bias = np.multiply(bias, mul_tensor)
+        t[bn.input[2]] = np.add(_bias, add_tensor)
+
+        # connect output of bn to output of add
+        bn.output[0] = add.output[0]
+
+        # remove mul and add nodes
+        graph.remove_node(mul.name)
+        graph.remove_node(add.name)
+
+        return graph
+

--- a/dlpy/model_conversion/write_onnx_model.py
+++ b/dlpy/model_conversion/write_onnx_model.py
@@ -146,10 +146,7 @@ def sas_to_onnx(layers, model_table, model_weights):
 
             # activation op
             if act.lower() != 'identity':
-                onnx_act = sas_to_onnx_activation(act)
-                act_op = helper.make_node(op_type=onnx_act,
-                                          inputs=act_input,
-                                          outputs=act_output)
+                act_op = make_onnx_activation(act, act_input, act_output)
                 nodes.append(act_op)
 
             # dropout op
@@ -248,10 +245,7 @@ def sas_to_onnx(layers, model_table, model_weights):
 
             # activation op
             if act.lower() != 'identity':
-                onnx_act = sas_to_onnx_activation(act)
-                act_op = helper.make_node(op_type=onnx_act,
-                                          inputs=act_input,
-                                          outputs=act_output)
+                act_op = make_onnx_activation(act, act_input, act_output)
                 nodes.append(act_op)
 
             # dropout op
@@ -389,10 +383,7 @@ def sas_to_onnx(layers, model_table, model_weights):
 
             # activation op
             if act.lower() != 'identity':
-                onnx_act = sas_to_onnx_activation(act)
-                act_op = helper.make_node(op_type=onnx_act,
-                                          inputs=act_input,
-                                          outputs=act_output)
+                act_op = make_onnx_activation(act, act_input, act_output)
                 nodes.append(act_op)
 
             # add output
@@ -488,10 +479,8 @@ def sas_to_onnx(layers, model_table, model_weights):
 
             # activation op
             if act.lower() != 'identity':
-                onnx_act = sas_to_onnx_activation(act)
-                nodes.append(helper.make_node(op_type=onnx_act,
-                                              inputs=act_input,
-                                              outputs=act_output))
+                act_op = make_onnx_activation(act, act_input, act_output)
+                nodes.append(act_op)
 
         elif layer.type == 'residual':
             act = layer.config['act']
@@ -514,10 +503,8 @@ def sas_to_onnx(layers, model_table, model_weights):
 
             # activation op
             if act.lower() != 'identity':
-                onnx_act = sas_to_onnx_activation(act)
-                nodes.append(helper.make_node(op_type=onnx_act,
-                                              inputs=act_input,
-                                              outputs=act_output))
+                act_op = make_onnx_activation(act, act_input, act_output)
+                nodes.append(act_op)
 
         elif layer.type == 'concat':
             act = layer.config['act']
@@ -552,10 +539,8 @@ def sas_to_onnx(layers, model_table, model_weights):
 
             # activation op
             if act.lower() != 'identity':
-                onnx_act = sas_to_onnx_activation(act)
-                nodes.append(helper.make_node(op_type=onnx_act,
-                                              inputs=act_input,
-                                              outputs=act_output))
+                act_op = make_onnx_activation(act, act_input, act_output)
+                nodes.append(act_op)
 
         elif layer.type == 'detection':
             continue
@@ -667,6 +652,20 @@ def sas_to_onnx_activation(activation):
         print('WARNING: Unsupported activation: '
               + str(activation) + '. Using identity.')
         return 'Identity'
+
+
+def make_onnx_activation(activation, act_input, act_output):
+    ''' Make onnx activation op '''
+    onnx_act = sas_to_onnx_activation(activation)
+    if onnx_act == 'LeakyRelu':
+        return helper.make_node(op_type=onnx_act,
+                                inputs=act_input,
+                                outputs=act_output,
+                                alpha=0.1)
+    else:
+        return helper.make_node(op_type=onnx_act,
+                                inputs=act_input,
+                                outputs=act_output)
 
 
 def get_padding(layer):

--- a/dlpy/model_conversion/write_onnx_model.py
+++ b/dlpy/model_conversion/write_onnx_model.py
@@ -72,14 +72,15 @@ def sas_to_onnx(layers, model_table, model_weights):
             W = int(layer.config['width'])
             C = int(layer.config['n_channels'])
             if layer.config['offsets'] is None:
-                offsets = [0., 0., 0.]
+                offsets = [0.] * C
             else:
                 offsets = [float(i) for i in layer.config['offsets']]
             if layer.config['scale'] is None:
                 scale = 1.
             else:
                 scale = float(layer.config['scale'])
-            if offsets != [0., 0., 0.] or scale != 1.:
+
+            if offsets != [0.] * C or scale != 1.:
                 graph_input = layer.name + '_'
                 scale_op = helper.make_node(op_type='ImageScaler',
                                             inputs=[graph_input],

--- a/dlpy/tests/test_model.py
+++ b/dlpy/tests/test_model.py
@@ -551,7 +551,7 @@ class TestModel(unittest.TestCase):
         self.assertTrue(r.severity == 0)
 
         model1.save_weights_csv(self.data_dir)
-        weights_path = os.path.join(self.data_dir_local, 'Simple_CNN1_weights.csv')
+        weights_path = os.path.join(self.data_dir, 'Simple_CNN1_weights.csv')
         model1.deploy(self.data_dir_local, output_format='onnx', model_weights=weights_path)
 
     def test_model21(self):

--- a/dlpy/tests/test_onnx_graph.py
+++ b/dlpy/tests/test_onnx_graph.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import os
+import unittest
+import numpy as np
+from dlpy.model_conversion.onnx_graph import OnnxGraph, OnnxNode
+
+class TestGraph(unittest.TestCase):
+    def _generate_graph1(self):
+        from onnx import helper, numpy_helper, TensorProto
+        input0 = helper.make_tensor_value_info('data0',
+                                               TensorProto.FLOAT,
+                                               [1, 3, 224, 224])
+
+        input1 = helper.make_tensor_value_info('conv0',
+                                               TensorProto.FLOAT,
+                                               [64, 3, 7, 7])
+        
+        output0 = helper.make_tensor_value_info('output0',
+                                                TensorProto.FLOAT,
+                                                [1, 64, 122, 122])
+
+        conv_op = helper.make_node('Conv',
+                                   inputs=['data0', 'conv0'],
+                                   outputs=['output0'],
+                                   kernel_shape=[7, 7],
+                                   pads=[3, 3, 3, 3],
+                                   strides=[2, 2])
+
+
+        conv0 = np.random.rand(64, 3, 7, 7).astype('float32')
+        init0 = numpy_helper.from_array(conv0,
+                                        name='conv0')
+
+        graph = helper.make_graph(
+            nodes=[conv_op],
+            name='',
+            inputs=[input0, input1],
+            outputs=[output0],
+            initializer=[init0]
+        )
+        return graph
+
+    def test_graph1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        self.assertEqual(len(graph.node), 1)
+        self.assertEqual(len(graph.initializer), 1)
+        self.assertEqual(len(graph.input), 2)
+        self.assertEqual(len(graph.output), 1)
+        self.assertEqual(len(graph.uninitialized), 1)
+
+        self.assertEqual(graph.node[0].name, 'Conv_0')
+        self.assertTrue(not graph.node[0].parents)
+        self.assertTrue(not graph.node[0].children)
+
+        self.assertEqual(graph.initializer[0].name, 'conv0')
+        self.assertEqual(graph.input[0].name, 'data0')
+        self.assertEqual(graph.input[1].name, 'conv0')
+        self.assertEqual(graph.output[0].name, 'output0')
+
+        self.assertTrue('conv0' in graph.tensor_dict)
+        self.assertEqual(graph.uninitialized[0].name, 'data0')
+
+    def test_graph_connection(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+        
+        from onnx import helper, numpy_helper, TensorProto
+        input0 = helper.make_tensor_value_info('data0',
+                                               TensorProto.FLOAT,
+                                               [1, 3, 224, 224])
+
+        input1 = helper.make_tensor_value_info('conv0',
+                                               TensorProto.FLOAT,
+                                               [64, 3, 7, 7])
+        
+        output0 = helper.make_tensor_value_info('output0',
+                                                TensorProto.FLOAT,
+                                                [1, 64, 122, 122])
+
+        conv_op = helper.make_node('Conv',
+                                   inputs=['data0', 'conv0'],
+                                   outputs=['conv_out'],
+                                   kernel_shape=[7, 7],
+                                   pads=[3, 3, 3, 3],
+                                   strides=[2, 2])
+
+        identity_op = helper.make_node('Identity',
+                                       inputs=['conv_out'],
+                                       outputs=['output0'])
+
+        conv0 = np.random.rand(64, 3, 7, 7).astype('float32')
+        init0 = numpy_helper.from_array(conv0,
+                                        name='conv0')
+
+        graph_ = helper.make_graph(
+            nodes=[conv_op, identity_op],
+            name='',
+            inputs=[input0, input1],
+            outputs=[output0],
+            initializer=[init0]
+        )
+
+        graph = OnnxGraph.from_onnx(graph_)
+
+        self.assertEqual(len(graph.node), 2)
+
+        self.assertEqual(graph.node[0].name, 'Conv_0')
+        self.assertTrue(not graph.node[0].parents)
+        self.assertEqual(len(graph.node[0].children), 1)
+        self.assertEqual(graph.node[0].children[0].name, 'Identity_1')
+        self.assertTrue('conv0' in graph.node[0].tensors)
+
+        self.assertEqual(graph.node[1].name, 'Identity_1')
+        self.assertEqual(len(graph.node[1].parents), 1)
+        self.assertEqual(graph.node[1].parents[0].name, 'Conv_0')
+        self.assertTrue(not graph.node[1].children)
+        self.assertTrue(not graph.node[1].tensors)
+
+    def test_get_node(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        self.assertEqual(graph.get_node('Conv_0').name, 'Conv_0')
+        self.assertEqual(graph.get_node_index('Conv_0'), 0)
+        self.assertEqual(graph.get_node('abcdef'), None)
+        self.assertEqual(graph.get_node_index('abcdef'), None)
+
+    def test_remove_node(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        graph.remove_node('Conv_0')
+        self.assertTrue(not graph.node)
+    
+    def test_remove_node1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        graph.remove_node('abcdef')
+        self.assertEqual(len(graph.node), 1)
+    
+    def test_replace_node(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        node_ = graph.node[0]
+        new_node = helper.make_node('Identity',
+                                    inputs=node_.input,
+                                    outputs=node_.output,
+                                    name='test_node')
+        new_node = OnnxNode(new_node)
+        graph.replace_node('Conv_0', new_node)
+
+        self.assertEqual(len(graph.node), 1)
+        self.assertEqual(graph.node[0].name, 'test_node')
+    
+    def test_replace_node1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        node_ = graph.node[0]
+        new_node = helper.make_node('Identity',
+                                    inputs=node_.input,
+                                    outputs=node_.output,
+                                    name='test_node')
+        new_node = OnnxNode(new_node)
+        graph.replace_node('abcdef', new_node)
+
+        self.assertEqual(len(graph.node), 1)
+        self.assertEqual(graph.node[0].name, 'Conv_0')
+
+    def test_insert_node(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        new_node = helper.make_node('Identity',
+                                    inputs=[],
+                                    outputs=[],
+                                    name='test_node')
+        new_node = OnnxNode(new_node)
+        graph.insert_node('Conv_0', new_node)
+
+        self.assertEqual(len(graph.node), 2)
+        self.assertEqual(graph.node[1].name, 'test_node')
+    
+    def test_insert_node1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        new_node = helper.make_node('Identity',
+                                    inputs=[],
+                                    outputs=[],
+                                    name='test_node')
+        new_node = OnnxNode(new_node)
+        graph.insert_node('abcdef', new_node)
+
+        self.assertEqual(len(graph.node), 1)
+        self.assertEqual(graph.node[0].name, 'Conv_0')
+
+    def test_get_input(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        i = graph.get_input('data0')
+        self.assertEqual(i.name, 'data0')
+        self.assertEqual([d.dim_value for d in i.type.tensor_type.shape.dim],
+                          [1, 3, 224, 224])
+
+    def test_get_input1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        i = graph.get_input('abcdef')
+        self.assertEqual(i, None)
+
+    def test_add_input(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper, TensorProto
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        value_info = helper.make_tensor_value_info('data1',
+                                                   TensorProto.FLOAT,
+                                                   [1, 3, 299, 299])
+        graph.add_input(value_info)
+        self.assertEqual(len(graph.input), 3)
+        self.assertEqual(graph.input[-1], value_info)
+    
+    def test_replace_input(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper, TensorProto
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        value_info = helper.make_tensor_value_info('data1',
+                                                   TensorProto.FLOAT,
+                                                   [1, 3, 299, 299])
+        graph.replace_input('data0', value_info)
+        self.assertEqual(len(graph.input), 2)
+        self.assertEqual(graph.input[0], value_info)
+
+    def test_get_initializer(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import numpy_helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        init = graph.get_initializer('conv0')
+        conv0 = numpy_helper.to_array(init)
+
+        self.assertEqual(init.name, 'conv0')
+        self.assertTrue(np.array_equal(conv0, graph.tensor_dict['conv0']))
+    
+    def test_get_initializer1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        init = graph.get_initializer('abcdef')
+        self.assertEqual(init, None)
+
+    def test_add_initializer(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import numpy_helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        conv1 = np.random.rand(64, 3, 7, 7).astype('float32')
+        init1 = numpy_helper.from_array(conv1,
+                                        name='conv1')
+        graph.add_initializer(init1)
+
+        self.assertEqual(len(graph.initializer), 2)
+        self.assertEqual(graph.initializer[1], init1)
+    
+    def test_replace_initializer(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import numpy_helper
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        conv1 = np.random.rand(64, 3, 7, 7).astype('float32')
+        init1 = numpy_helper.from_array(conv1,
+                                        name='conv1')
+        graph.replace_initializer('conv0', init1)
+
+        self.assertEqual(len(graph.initializer), 1)
+        self.assertEqual(graph.initializer[0], init1)
+    
+    def test_clean_init(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        graph.remove_node('Conv_0')
+        graph.clean_init()
+
+        self.assertTrue(not graph.input)
+        self.assertTrue(not graph.initializer)
+        self.assertTrue(not graph.tensor_dict)
+
+    def test_make_model(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        graph_ = self._generate_graph1()
+        graph = OnnxGraph.from_onnx(graph_)
+
+        model = graph.make_onnx()
+        g = model.graph
+        self.assertEqual(len(g.node), 1)
+        self.assertEqual(g.node[0].name, 'Conv_0')
+        self.assertEqual(len(g.input), 2)
+

--- a/dlpy/tests/test_onnx_transforms.py
+++ b/dlpy/tests/test_onnx_transforms.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import os
+import unittest
+import numpy as np
+from dlpy.model_conversion.onnx_transforms import (Transformer, OpTypePattern,
+                                                   ConstToInitializer, 
+                                                   InitReshape, InitUnsqueeze,
+                                                   FuseMulAddBN)
+from dlpy.model_conversion.onnx_graph import OnnxGraph
+
+class TestTransformer(unittest.TestCase):
+    def test_transformer1(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper, numpy_helper
+        node1 = helper.make_node(
+            'Identity',
+            inputs=['in'],
+            outputs=['out'],
+            name='Identity_1'
+        )
+
+        graph_ = helper.make_graph(
+            nodes=[node1],
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=[]
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+
+        pattern = OpTypePattern('Identity')
+        transform = Transformer(pattern)
+        self.assertTrue(transform.match(graph.node[0]))
+
+    def test_transformer2(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper, numpy_helper
+
+        nodes = [
+            helper.make_node('Unsqueeze',
+                inputs=['unsqueeze_in'],
+                outputs=['unsqueeze_out'],
+                name='Unsqueeze_1',
+                axes=[1, 2]
+            ),
+            helper.make_node('Mul',
+                inputs=['unsqueeze_out', 'mul1'],
+                outputs=['mul_out'],
+                name='Mul_2'
+            ),
+            helper.make_node('Add',
+                inputs=['mul_out', 'add1'],
+                outputs=['add_out'],
+                name='Add_3'
+            )
+        ]
+
+        graph_ = helper.make_graph(
+            nodes=nodes,
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=[]
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+        transform = Transformer()
+        pattern = OpTypePattern('Unsqueeze',
+                                outputs=[OpTypePattern('Mul', outputs=['Add'])])
+
+        self.assertTrue(transform.match(graph.node[0], pattern))
+        self.assertFalse(transform.match(graph.node[1], pattern))
+
+    def test_transformer3(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper, numpy_helper
+
+        nodes = [
+            helper.make_node('Unsqueeze',
+                inputs=['unsqueeze_in'],
+                outputs=['unsqueeze_out'],
+                name='Unsqueeze_1',
+                axes=[1, 2]
+            ),
+            helper.make_node('Mul',
+                inputs=['unsqueeze_out', 'mul1'],
+                outputs=['mul_out'],
+                name='Mul_2'
+            ),
+            helper.make_node('Add',
+                inputs=['mul_out', 'add1'],
+                outputs=['add_out'],
+                name='Add_3'
+            ),
+        ]
+
+        graph_ = helper.make_graph(
+            nodes=nodes,
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=[]
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+
+        pattern = OpTypePattern('Add', name='op3')
+        pattern = OpTypePattern('Mul', name='op2', outputs=[pattern])
+        pattern = OpTypePattern('Unsqueeze', name='op1', outputs=[pattern])
+
+        transform = Transformer(pattern)
+        mapping = transform.get_mapping(graph.node[0])
+
+        self.assertEqual(len(mapping), 3)
+        self.assertEqual(mapping['op3'].name, 'Add_3')
+        self.assertEqual(mapping['op2'].name, 'Mul_2')
+        self.assertEqual(mapping['op1'].name, 'Unsqueeze_1')
+
+    def test_init_unsqueeze(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+        
+        from onnx import helper, numpy_helper
+        unsqueeze_1 = helper.make_node(
+            'Unsqueeze',
+            inputs=['unsqueeze_in'],
+            outputs=['unsqueeze_out'],
+            name='Unsqueeze_1',
+            axes=[1, 2]
+        )
+
+        unsqueeze_in = np.random.rand(64).astype('float32')
+        init = numpy_helper.from_array(unsqueeze_in, name='unsqueeze_in')
+        graph_ = helper.make_graph(
+            nodes=[unsqueeze_1],
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=[init]
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+        graph = InitUnsqueeze()(graph)
+
+        self.assertEqual(len(graph.node), 0)
+        self.assertTrue('unsqueeze_out' in graph.tensor_dict)
+        t = graph.tensor_dict['unsqueeze_out']
+        t = np.squeeze(t)
+        self.assertTrue(np.array_equal(unsqueeze_in, t))
+    
+    def test_init_reshape(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+        
+        from onnx import helper, numpy_helper
+        reshape_1 = helper.make_node(
+            'Reshape',
+            inputs=['reshape_in', 'shape'],
+            outputs=['reshape_out'],
+            name='Reshape_1'
+        )
+
+        reshape_in = np.random.rand(64).astype('float32')
+        shape = np.array([8, 8])
+        init = numpy_helper.from_array(reshape_in, name='reshape_in')
+        shape_init = numpy_helper.from_array(shape, name='shape')
+        graph_ = helper.make_graph(
+            nodes=[reshape_1],
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=[init, shape_init]
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+        graph = InitReshape()(graph)
+
+        self.assertEqual(len(graph.node), 0)
+        self.assertTrue('reshape_out' in graph.tensor_dict)
+        t = graph.tensor_dict['reshape_out']
+        self.assertEqual(t.shape, (8, 8))
+
+    def test_const_to_initializer(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+        
+        from onnx import helper
+        values = np.random.randn(5, 5).astype(np.float32)
+        const_1 = helper.make_node(
+            'Constant',
+            inputs=[],
+            outputs=['constant_out'],
+            name='Constant_1',
+            value=onnx.helper.make_tensor(
+                name='const_tensor',
+                data_type=onnx.TensorProto.FLOAT,
+                dims=values.shape,
+                vals=values.flatten().astype(float),
+            )
+        )
+
+        graph_ = helper.make_graph(
+            nodes=[const_1],
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=[]
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+        graph = ConstToInitializer()(graph)
+
+        self.assertEqual(len(graph.node), 0)
+        self.assertTrue('constant_out' in graph.tensor_dict)
+        t = graph.tensor_dict['constant_out']
+        self.assertTrue(np.array_equal(values, t))
+
+    def test_fuse_mul_add_bn(self):
+        try:
+            import onnx
+        except:
+            unittest.TestCase.skipTest(self, 'onnx package not found')
+
+        from onnx import helper, numpy_helper
+        nodes = [
+            helper.make_node('BatchNormalization',
+                inputs=['data', 'bn_scale', 'bn_bias', 'bn_mean', 'bn_var'],
+                outputs=['bn_out'],
+                name='BatchNormalization_1'
+            ),
+            helper.make_node('Mul',
+                inputs=['bn_out', 'mul1'],
+                outputs=['mul_out'],
+                name='Mul_2'
+            ),
+            helper.make_node('Add',
+                inputs=['mul_out', 'add1'],
+                outputs=['add_out'],
+                name='Add_3'
+            )
+        ]
+        
+        bn_scale = np.random.rand(64).astype('float32')
+        bn_bias = np.random.rand(64).astype('float32')
+        bn_mean = np.random.rand(64).astype('float32')
+        bn_var = np.random.rand(64).astype('float32')
+        mul1 = np.random.rand(64, 1, 1)
+        add1 = np.random.rand(64, 1, 1)
+
+        initializer = [
+            numpy_helper.from_array(bn_scale, name='bn_scale'),
+            numpy_helper.from_array(bn_bias, name='bn_bias'),
+            numpy_helper.from_array(bn_mean, name='bn_mean'),
+            numpy_helper.from_array(bn_var, name='bn_var'),
+            numpy_helper.from_array(mul1, name='mul1'),
+            numpy_helper.from_array(add1, name='add1')
+        ]
+
+        graph_ = helper.make_graph(
+            nodes=nodes,
+            name='',
+            inputs=[],
+            outputs=[],
+            initializer=initializer
+        )
+        graph = OnnxGraph.from_onnx(graph_)
+        graph = FuseMulAddBN()(graph)
+
+        self.assertEqual(len(graph.node), 1)
+        self.assertEqual(graph.node[0].name, 'BatchNormalization_1')
+        s = graph.tensor_dict['bn_scale']
+        b = graph.tensor_dict['bn_bias']
+        s_ = np.multiply(bn_scale, np.squeeze(mul1))
+        b_ = np.multiply(bn_bias, np.squeeze(mul1))
+        b_ = np.add(b_, np.squeeze(add1))
+        self.assertTrue(np.array_equal(s, s_))
+        self.assertTrue(np.array_equal(b, b_))
+


### PR DESCRIPTION
This pull request adds initial support for graph transformers when importing ONNX models.  These transformers rewrite subgraphs into a structure that is importable by DLPy.  Overview of the changes:  

New files:
onnx_graph.py - classes and utilities for onnx graph and node protos  
onnx_transforms.py - transformer base class and implementations of various transformers  
test_onnx_graph.py - tests for onnx_graph  
test_onnx_transforms.py - tests for onnx_transforms  

Changed:  
sas_onnx_parse.py - Add transformations when importing models  
write_onnx_model.py - Bug fixes:  
- Fix incorrect alpha value for leakyrelu activation  
- Fix imagescaler for single channel inputs  
- Fix missing output valueinfos for detection layer and loss-only output layer  
