### PR TITLE
Fix errors importing Caffe model

### DIFF
--- a/dlpy/attribute_utils.py
+++ b/dlpy/attribute_utils.py
@@ -58,17 +58,17 @@ def create_extended_attributes(conn, model_name, layers, data_spec, label_file_n
 
     # ensure list of strings
     if not isinstance(layers,list):
-        raise TypeError('layers must be a list of strings.')
+        raise TypeError('Parameter layers must be a list of strings.')
     else:
         if not all(isinstance(x,str) for x in layers):
-            raise TypeError('all layers elements must be strings.')
+            raise TypeError('Some elements of the layers list are not strings.')
 
     # ensure list of data specs
     if not isinstance(data_spec,list):
-        raise TypeError('data_spec must be a list of DataSpec objects.')
+        raise TypeError('Parameter data_spec must be a list of DataSpec objects.')
     else:
         if not all(isinstance(x,DataSpec) for x in data_spec):
-            raise TypeError('all data_spec elements must be DataSpec objects.')
+            raise TypeError('Some elements of the data_spec list are not DataSpec objects.')
 
     # read user-supplied labels
     if label_file_name is None:

--- a/dlpy/attribute_utils.py
+++ b/dlpy/attribute_utils.py
@@ -55,6 +55,14 @@ def create_extended_attributes(conn, model_name, layers, data_spec, label_file_n
         
     '''
 
+    # ensure list of strings
+    if not isinstance(layers,list):
+        raise TypeError('layers must be a list of strings.')
+
+    # ensure list of data specs
+    if not isinstance(data_spec,list):
+        raise TypeError('data_spec must be a list of DataSpec objects.')
+            
     # read user-supplied labels
     if label_file_name is None:
         labels = None

--- a/dlpy/attribute_utils.py
+++ b/dlpy/attribute_utils.py
@@ -25,7 +25,8 @@ import pandas as pd
 import swat as sw
 import string
 import warnings
-import struct    
+import struct
+from dlpy.model import DataSpec
 
 def create_extended_attributes(conn, model_name, layers, data_spec, label_file_name=None):
 
@@ -58,11 +59,17 @@ def create_extended_attributes(conn, model_name, layers, data_spec, label_file_n
     # ensure list of strings
     if not isinstance(layers,list):
         raise TypeError('layers must be a list of strings.')
+    else:
+        if not all(isinstance(x,str) for x in layers):
+            raise TypeError('all layers elements must be strings.')
 
     # ensure list of data specs
     if not isinstance(data_spec,list):
         raise TypeError('data_spec must be a list of DataSpec objects.')
-            
+    else:
+        if not all(isinstance(x,DataSpec) for x in data_spec):
+            raise TypeError('all data_spec elements must be DataSpec objects.')
+
     # read user-supplied labels
     if label_file_name is None:
         labels = None


### PR DESCRIPTION
This code update will fix open issue #120 and another Caffe conversion error I found.  The code update also brings the Python source code more in line with PEP-8 guidelines.  Most of the diffs you see are the result of changing variable names from camel case (aVarName) to PEP-8 standards (a_var_name).  The other substantial change was moving away from the use of the exec() function to the eval() function since the exec() function behavior changed between Python 2 and Python 3.