### PR TITLE
Fix bug dropping CASLIB.

### DIFF
--- a/dlpy/images.py
+++ b/dlpy/images.py
@@ -193,7 +193,7 @@ class ImageTable(CASTable):
             casout['name'] = random_name()
 
         if caslib is None:
-            caslib, path = caslibify(conn, path, task='load')
+            caslib, path, tmp_caslib = caslibify(conn, path, task='load')
 
         if caslib is None and path is None:
             print('Cannot create a caslib for the provided path. Please make sure that the path is accessible from'
@@ -224,7 +224,7 @@ class ImageTable(CASTable):
         out.set_connection(conn)
 
         # drop the temp caslib
-        if caslib is not None:
+        if (caslib is not None) and tmp_caslib:
             conn.retrieve('dropcaslib', _messagelevel='error', caslib=caslib)
 
         return out

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -645,7 +645,7 @@ class Network(Layer):
 
         '''
 
-        cas_lib_name, file_name = caslibify(self.conn, path, task='load')
+        cas_lib_name, file_name, tmp_caslib = caslibify(self.conn, path, task='load')
 
         self._retrieve_('table.loadtable',
                         caslib=cas_lib_name,
@@ -740,7 +740,7 @@ class Network(Layer):
                                             name=self.model_name + '_weights_attr'))
                 self.set_weights_attr(self.model_name + '_weights_attr')
 
-        if cas_lib_name is not None:
+        if (cas_lib_name is not None) and tmp_caslib:
             self._retrieve_('table.dropcaslib', message_level = 'error', caslib = cas_lib_name)
 
     def load_weights(self, path, labels=False, data_spec=None, label_file_name=None, label_length=None):
@@ -854,7 +854,7 @@ class Network(Layer):
             data specification for input and output layer(s)
 
         '''
-        cas_lib_name, file_name = caslibify(self.conn, path, task='load')
+        cas_lib_name, file_name, tmp_caslib = caslibify(self.conn, path, task='load')
 
         if data_spec:
 
@@ -905,7 +905,7 @@ class Network(Layer):
 
         self.set_weights(self.model_name + '_weights')
 
-        if cas_lib_name is not None:
+        if (cas_lib_name is not None) and tmp_caslib:
             self._retrieve_('table.dropcaslib', message_level = 'error', caslib = cas_lib_name)
 
     def load_weights_from_file_with_labels(self, path, format_type='KERAS', data_spec=None, label_file_name=None, label_length=None):
@@ -928,7 +928,7 @@ class Network(Layer):
             Length of the classification labels (in characters).
 
         '''
-        cas_lib_name, file_name = caslibify(self.conn, path, task='load')
+        cas_lib_name, file_name, tmp_caslib = caslibify(self.conn, path, task='load')
 
         if (label_file_name):
             from dlpy.utils import get_user_defined_labels_table
@@ -985,7 +985,7 @@ class Network(Layer):
 
         self.set_weights(self.model_name + '_weights')
 
-        if cas_lib_name is not None:
+        if (cas_lib_name is not None) and tmp_caslib:
             self._retrieve_('table.dropcaslib', message_level = 'error', caslib = cas_lib_name)
 
     def load_weights_from_table(self, path):
@@ -999,7 +999,7 @@ class Network(Layer):
             contains the weight table.
 
         '''
-        cas_lib_name, file_name = caslibify(self.conn, path, task='load')
+        cas_lib_name, file_name, tmp_caslib = caslibify(self.conn, path, task='load')
 
         self._retrieve_('table.loadtable',
                         caslib=cas_lib_name,
@@ -1027,7 +1027,7 @@ class Network(Layer):
 
         self.model_weights = self.conn.CASTable(name=self.model_name + '_weights')
 
-        if cas_lib_name is not None:
+        if (cas_lib_name is not None) and tmp_caslib:
             self._retrieve_('table.dropcaslib', message_level = 'error', caslib = cas_lib_name)
 
     def set_weights_attr(self, attr_tbl, clear=True):
@@ -1151,7 +1151,7 @@ class Network(Layer):
         # if path.endswith(os.path.sep):
         #    path = path[:-1]
 
-        caslib, path_remaining = caslibify(self.conn, path, task = 'save')
+        caslib, path_remaining, tmp_caslib = caslibify(self.conn, path, task = 'save')
 
         _file_name_ = self.model_name.replace(' ', '_')
         _extension_ = '.sashdat'
@@ -1195,7 +1195,7 @@ class Network(Layer):
 
         print('NOTE: Model table saved successfully.')
 
-        if caslib is not None:
+        if (caslib is not None) and tmp_caslib:
             self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
 
     def save_weights_csv(self, path):
@@ -1217,7 +1217,7 @@ class Network(Layer):
                             casout = dict(name = self.model_weights.name,
                                           replace = True))
 
-        caslib, path_remaining = caslibify(self.conn, path, task = 'save')
+        caslib, path_remaining, tmp_caslib = caslibify(self.conn, path, task = 'save')
         _file_name_ = self.model_name.replace(' ', '_')
         _extension_ = '.csv'
         weights_tbl_file = path_remaining + _file_name_ + '_weights' + _extension_
@@ -1230,7 +1230,7 @@ class Network(Layer):
 
         print('NOTE: Model weights csv saved successfully.')
 
-        if caslib is not None:
+        if (caslib is not None) and tmp_caslib:
             self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
 
     def save_to_onnx(self, path, model_weights = None):

--- a/dlpy/tests/test_model.py
+++ b/dlpy/tests/test_model.py
@@ -84,7 +84,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -95,6 +95,9 @@ class TestModel(unittest.TestCase):
             for msg in r.messages:
                 print(msg)
         self.assertTrue(r.severity <= 1)
+        
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
 
     def test_model2(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
@@ -109,7 +112,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -121,6 +124,9 @@ class TestModel(unittest.TestCase):
         r2 = model1.predict(data='eee')
         self.assertTrue(r2.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model3(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -134,7 +140,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -152,6 +158,9 @@ class TestModel(unittest.TestCase):
         r3 = model1.predict(data='eee')
         self.assertTrue(r3.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model4(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -165,7 +174,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -177,6 +186,9 @@ class TestModel(unittest.TestCase):
         r2 = model1.evaluate(data='eee')
         self.assertTrue(r2.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model5(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -190,7 +202,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -208,6 +220,9 @@ class TestModel(unittest.TestCase):
         r3 = model1.evaluate(data='eee')
         self.assertTrue(r3.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model6(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -221,7 +236,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -230,6 +245,9 @@ class TestModel(unittest.TestCase):
         r = model1.fit(data='eee', inputs='_image_', target='_label_', save_best_weights=True)
         self.assertTrue(r.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model7(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -243,7 +261,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -255,6 +273,9 @@ class TestModel(unittest.TestCase):
         r2 = model1.predict(data='eee', use_best_weights=True)
         self.assertTrue(r2.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model8(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -268,7 +289,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -280,6 +301,9 @@ class TestModel(unittest.TestCase):
         r2 = model1.predict(data='eee')
         self.assertTrue(r2.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model9(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -293,7 +317,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -305,6 +329,9 @@ class TestModel(unittest.TestCase):
         r2 = model1.evaluate(data='eee', use_best_weights=True)
         self.assertTrue(r2.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model10(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -318,7 +345,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -332,6 +359,9 @@ class TestModel(unittest.TestCase):
 
         model1.save_to_table(self.data_dir)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model11(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -345,7 +375,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -363,6 +393,9 @@ class TestModel(unittest.TestCase):
         r3 = model1.evaluate(data='eee', use_best_weights=True)
         self.assertTrue(r3.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model12(self):
         model1 = Sequential(self.s, model_table='Simple_CNN1')
         model1.add(InputLayer(3, 224, 224))
@@ -376,7 +409,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -394,6 +427,9 @@ class TestModel(unittest.TestCase):
         r3 = model1.predict(data='eee', use_best_weights=True)
         self.assertTrue(r3.severity == 0)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model13(self):
         model = Sequential(self.s, model_table='simple_cnn')
         model.add(InputLayer(3, 224, 224))
@@ -485,7 +521,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -496,6 +532,9 @@ class TestModel(unittest.TestCase):
 
         model1.save_weights_csv(self.data_dir)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model19(self):
         try:
             import onnx
@@ -514,7 +553,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -525,6 +564,9 @@ class TestModel(unittest.TestCase):
 
         model1.deploy(self.data_dir, output_format='onnx')
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model20(self):
         try:
             import onnx
@@ -543,7 +585,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -556,6 +598,9 @@ class TestModel(unittest.TestCase):
         weights_path = os.path.join(self.data_dir, 'Simple_CNN1_weights.csv')
         model1.deploy(self.data_dir_local, output_format='onnx', model_weights=weights_path)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model21(self):
         try:
             import onnx
@@ -579,7 +624,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -590,6 +635,9 @@ class TestModel(unittest.TestCase):
 
         model1.deploy(self.data_dir, output_format='onnx')
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model22(self):
         try:
             import onnx
@@ -611,7 +659,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -622,6 +670,9 @@ class TestModel(unittest.TestCase):
 
         model1.deploy(self.data_dir, output_format='onnx')
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model22_1(self):
         try:
             import onnx
@@ -640,7 +691,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -657,6 +708,9 @@ class TestModel(unittest.TestCase):
         init = numpy_helper.to_array(m.graph.initializer[1])
         self.assertTrue(np.array_equal(init, [ -1,  2, 448, 448]))
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model23(self):
         try:
             import onnx
@@ -677,7 +731,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -688,6 +742,9 @@ class TestModel(unittest.TestCase):
 
         model1.deploy(self.data_dir, output_format='onnx')
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_model24(self):
         try:
             import onnx
@@ -763,7 +820,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path = self.data_dir + 'evaluate_obj_det_det.sashdat', task = 'load')
+        caslib, path, tmp_caslib = caslibify(self.s, path = self.data_dir + 'evaluate_obj_det_det.sashdat', task = 'load')
 
         self.s.table.loadtable(caslib = caslib,
                                casout = {'name': 'evaluate_obj_det_det', 'replace': True},
@@ -795,6 +852,9 @@ class TestModel(unittest.TestCase):
         metrics = yolo_model.evaluate_object_detection(ground_truth = 'evaluate_obj_det_gt', coord_type = 'yolo',
                                                        detection_data = 'evaluate_obj_det_det', iou_thresholds=0.5)
 
+        if (caslib is not None) and tmp_caslib:
+            self.s.retrieve('table.dropcaslib', message_level = 'error', caslib = caslib)
+                                                       
     def test_model29(self):
         # test specifying output layer in Model.from_onnx_model
         try:
@@ -1180,7 +1240,7 @@ class TestModel(unittest.TestCase):
         model1.add(Pooling(2))
         model1.add(OutputLayer(act='softmax', n=2))
 
-        caslib, path = caslibify(self.s,
+        caslib, path, tmp_caslib = caslibify(self.s,
                                  path=self.data_dir+'images.sashdat',
                                  task='load')
         self.s.table.loadtable(caslib=caslib,
@@ -1199,6 +1259,9 @@ class TestModel(unittest.TestCase):
         self.assertAlmostEqual(onnx_model.graph.node[0].attribute[0].floats[2], 0.3)
         self.assertAlmostEqual(onnx_model.graph.node[0].attribute[1].f, 1/255.)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     def test_load_reshape_detection(self):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
@@ -1225,7 +1288,7 @@ class TestModel(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
-        caslib, path = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
+        caslib, path, tmp_caslib = caslibify(self.s, path=self.data_dir+'images.sashdat', task='load')
 
         self.s.table.loadtable(caslib=caslib,
                                casout={'name': 'eee', 'replace': True},
@@ -1257,6 +1320,9 @@ class TestModel(unittest.TestCase):
         ax = model1.plot_training_history(tick_frequency=tick_frequency)
         self.assertEqual(len(ax.xaxis.majorTicks), model1.n_epochs)
 
+        if (caslib is not None) and tmp_caslib:
+            self._retrieve_('table.dropcaslib', message_level = 'error', caslib = caslib)
+        
     @classmethod
     def tearDownClass(cls):
         # tear down tests


### PR DESCRIPTION
There was a bug dropping CASLIBs.  The previous code always dropped the specified CASLIB, whether it had be created within a DLPy function or not.  This led to some externally defined CASLIBs being dropped when they shouldn't have been.  The new code checks to see whether the CASLIB in question is a temporary CASLIB created by a DLPy function before dropping it.