### PR TITLE
External CASLIB dropped erroneously

### DIFF
--- a/dlpy/images.py
+++ b/dlpy/images.py
@@ -194,6 +194,8 @@ class ImageTable(CASTable):
 
         if caslib is None:
             caslib, path, tmp_caslib = caslibify(conn, path, task='load')
+        else:
+            tmp_caslib = False
 
         if caslib is None and path is None:
             print('Cannot create a caslib for the provided path. Please make sure that the path is accessible from'

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -1641,6 +1641,8 @@ def create_object_detection_table_no_xml(conn, data_path, coord_type, output, an
 
     if annotation_data_is_in_the_client == 0:
         caslib_annotation, path_after_ann_caslib, tmp_caslib = caslibify(conn, annotation_path, task='save')
+    else:
+        tmp_caslib = False
 
     label_tbl_name = random_name('obj_det')
     idjoin_format_length = len(max(label_files, key=len)) - len('.txt')
@@ -1746,7 +1748,7 @@ def create_object_detection_table_no_xml(conn, data_path, coord_type, output, an
             conn.table.droptable('output{}'.format(var))
         conn.table.droptable(det_img_table)
 
-    if (caslib_annotation is not None) and (tmp_caslib is not None) and tmp_caslib:
+    if (caslib_annotation is not None) and tmp_caslib:
         conn.retrieve('dropcaslib', _messagelevel='error', caslib=caslib_annotation)
 
     print("NOTE: Object detection table is successfully created.")

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -1746,7 +1746,7 @@ def create_object_detection_table_no_xml(conn, data_path, coord_type, output, an
             conn.table.droptable('output{}'.format(var))
         conn.table.droptable(det_img_table)
 
-    if (caslib_annotation is not None) and tmp_caslib:
+    if (caslib_annotation is not None) and (tmp_caslib is not None) and tmp_caslib:
         conn.retrieve('dropcaslib', _messagelevel='error', caslib=caslib_annotation)
 
     print("NOTE: Object detection table is successfully created.")


### PR DESCRIPTION
When a user supplies a previously defined CASLIB for certain DLPy functions, an unbound variable error can occur.  This problem is fixed by this pull request.