### PR TITLE
fix a bug in load_weights()

### DIFF
--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -779,13 +779,10 @@ class Network(Layer):
 
         server_sep = get_server_path_sep(self.conn)
 
-        if os.path.isfile(path):
-            if server_sep in path:
-                dir_name, file_name = path.rsplit(server_sep, 1)
-            else:
-                file_name = path
+        if server_sep in path:
+            dir_name, file_name = path.rsplit(server_sep, 1)
         else:
-            raise DLPyError('The specified file does not exist: ' + path)
+            file_name = path
 
         if file_name.lower().endswith('.sashdat'):
             self.load_weights_from_table(path)


### PR DESCRIPTION
The push fixes a bug in load_weights()
The issue happens when load caffemodel.h5 as a model and model weights.
The path option is a server-side path. 'if os.path.isfile(path):' is intended to check if the file exists but it is operating on client-side. I don't think we have a method to check server-side file by client python, so I remove the outer if statement.