### PR TITLE
support mobilenetv1 mobilnetv2 and shufflenetv1

### DIFF
--- a/dlpy/applications.py
+++ b/dlpy/applications.py
@@ -20,6 +20,7 @@
 
 import os
 import warnings
+import numpy as np
 import six
 
 from .sequential import Sequential
@@ -28,7 +29,7 @@ from .caffe_models import (model_vgg16, model_vgg19, model_resnet50,
                            model_resnet101, model_resnet152)
 from .keras_models import model_inceptionv3
 from .layers import (Input, InputLayer, Conv2d, Pooling, Dense, BN, OutputLayer, Detection, Concat, Reshape, Recurrent,
-                     RegionProposal, ROIPooling, FastRCNN, GlobalAveragePooling2D)
+                     RegionProposal, ROIPooling, FastRCNN, GlobalAveragePooling2D, GroupConv2d, ChannelShuffle, Res)
 from .model import Model
 from .utils import random_name, DLPyError
 
@@ -1296,7 +1297,7 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
     return model
 
 
-def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE',  n_classes=1000, n_channels=3, width=224, height=224, scale=1,
+def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                    batch_norm_first=False, random_flip='none', random_crop='none', offsets=(103.939, 116.779, 123.68),
                    pre_trained_weights=False, pre_trained_weights_file=None, include_top=False):
     '''
@@ -1308,6 +1309,10 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE',  n_classes=1000, n_channe
         Specifies the CAS connection object.
     model_table : string or dict or CAS table, optional
         Specifies the CAS table to store the deep learning model.
+    n_classes : int, optional
+        Specifies the number of classes. If None is assigned, the model will
+        automatically detect the number of classes based on the training set.
+        Default: 1000
     batch_norm_first : bool, optional
         Specifies whether to have batch normalization layer before the
         convolution layer in the residual block.  For a detailed discussion
@@ -1315,10 +1320,6 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE',  n_classes=1000, n_channe
         mappings in deep residual networks." European Conference on Computer
         Vision. Springer International Publishing, 2016.
         Default: False
-     n_classes : int, optional
-        Specifies the number of classes. If None is assigned, the model will
-        automatically detect the number of classes based on the training set.
-        Default: 1000
     n_channels : int, optional
         Specifies the number of the channels (i.e., depth) of the input layer.
         Default: 3
@@ -2070,6 +2071,574 @@ def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_o
     model.add(GlobalAveragePooling2D())
 
     model.add(OutputLayer(act='softmax', n=n_classes))
+
+    return model
+
+
+def MobileNetV1(conn, model_table='MobileNetV1', n_classes=1000, n_channels=3, width=224, height=224,
+                random_flip='none', random_crop='none', random_mutation='none',
+                norm_stds=(255*0.229, 255*0.224, 255*0.225), offsets=(255*0.485, 255*0.456, 255*0.406),
+                alpha=1, depth_multiplier=1):
+    '''
+    Generates a deep learning model with the MobileNetV1 architecture.
+    The implementation is revised based on https://github.com/keras-team/keras-applications/blob/master/keras_applications/mobilenet.py
+
+    Parameters
+    ----------
+    conn : CAS
+        Specifies the CAS connection object.
+    model_table : string or dict or CAS table, optional
+        Specifies the CAS table to store the deep learning model.
+    n_classes : int, optional
+        Specifies the number of classes. If None is assigned, the model will
+        automatically detect the number of classes based on the training set.
+        Default: 1000
+    n_channels : int, optional
+        Specifies the number of the channels (i.e., depth) of the input layer.
+        Default: 3
+    width : int, optional
+        Specifies the width of the input layer.
+        Default: 32
+    height : int, optional
+        Specifies the height of the input layer.
+        Default: 32
+    random_flip : string, optional
+        Specifies how to flip the data in the input layer when image data is
+        used. Approximately half of the input data is subject to flipping.
+        Valid Values: 'h', 'hv', 'v', 'none'
+        Default: 'none'
+    random_crop : string, optional
+        Specifies how to crop the data in the input layer when image data is
+        used. Images are cropped to the values that are specified in the width
+        and height parameters. Only the images with one or both dimensions
+        that are larger than those sizes are cropped.
+        Valid Values: 'none', 'unique'
+        Default: 'none'
+    random_mutation : string, optional
+        Specifies how to apply data augmentations/mutations to the data in the input layer.
+        Valid Values: 'none', 'random'
+        Default: 'NONE'
+    norm_stds : double or iter-of-doubles, optional
+        Specifies a standard deviation for each channel in the input data.
+        The final input data is normalized with specified means and standard deviations.
+        Default: (255*0.229, 255*0.224, 255*0.225)
+    offsets : double or iter-of-doubles, optional
+        Specifies an offset for each channel in the input data. The final input
+        data is set after applying scaling and subtracting the specified offsets.
+        Default: (255*0.485, 255*0.456, 255*0.406)
+    alpha : int, optional
+        Specifies the width multiplier in the MobileNet paper
+        Default: 1
+    depth_multiplier : int, optional
+        Specifies the number of depthwise convolution output channels for each input channel.
+        Default: 1
+
+    Returns
+    -------
+    :class:`Model`
+
+    References
+    ----------
+    https://arxiv.org/pdf/1605.07146.pdf
+
+    '''
+    def _conv_block(inputs, filters, alpha, kernel = 3, stride = 1):
+        """Adds an initial convolution layer (with batch normalization
+
+        inputs:
+            Input tensor
+        filters:
+            the dimensionality of the output space
+        alpha: controls the width of the network.
+            - If `alpha` < 1.0, proportionally decreases the number
+                of filters in each layer.
+            - If `alpha` > 1.0, proportionally increases the number
+                of filters in each layer.
+            - If `alpha` = 1, default number of filters from the paper
+                 are used at each layer.
+        kernel:
+            specifying the width and height of the 2D convolution window.
+        strides:
+            the strides of the convolution
+
+        """
+        filters = int(filters * alpha)
+        x = Conv2d(filters, kernel, act = 'identity', include_bias = False, stride = stride, name = 'conv1')(inputs)
+        x = BN(name = 'conv1_bn', act='relu')(x)
+        return x, filters
+
+    def _depthwise_conv_block(inputs, n_groups, pointwise_conv_filters, alpha,
+                              depth_multiplier = 1, stride = 1, block_id = 1):
+        """Adds a depthwise convolution block.
+
+        inputs:
+            Input tensor
+        n_groups : int
+            number of groups
+        pointwise_conv_filters:
+            the dimensionality of the output space
+        alpha: controls the width of the network.
+            - If `alpha` < 1.0, proportionally decreases the number
+                of filters in each layer.
+            - If `alpha` > 1.0, proportionally increases the number
+                of filters in each layer.
+            - If `alpha` = 1, default number of filters from the paper
+                 are used at each layer.
+        depth_multiplier:
+            The number of depthwise convolution output channels
+        strides: An integer or tuple/list of 2 integers,
+            specifying the strides of the convolution
+        block_id: Integer, a unique identification designating
+            the block number.
+
+        """
+        pointwise_conv_filters = int(pointwise_conv_filters * alpha)
+
+        x = GroupConv2d(n_groups*depth_multiplier, n_groups, 3, stride = stride, act = 'identity',
+                        include_bias = False, name = 'conv_dw_%d' % block_id)(inputs)
+        x = BN(name = 'conv_dw_%d_bn' % block_id, act = 'relu')(x)
+
+        x = Conv2d(pointwise_conv_filters, 1, act = 'identity', include_bias = False, stride = 1,
+                   name = 'conv_pw_%d' % block_id)(x)
+        x = BN(name = 'conv_pw_%d_bn' % block_id, act = 'relu')(x)
+        return x, pointwise_conv_filters
+
+    parameters = locals()
+    input_parameters = _get_layer_options(input_layer_options, parameters)
+    inp = Input(**input_parameters, name = 'data')
+    x, depth = _conv_block(inp, 32, alpha, stride = 2)
+    x, depth = _depthwise_conv_block(x, depth, 64, alpha, depth_multiplier, block_id = 1)
+
+    x, depth = _depthwise_conv_block(x, depth, 128, alpha, depth_multiplier,
+                                     stride = 2, block_id = 2)
+    x, depth = _depthwise_conv_block(x, depth, 128, alpha, depth_multiplier, block_id = 3)
+
+    x, depth = _depthwise_conv_block(x, depth, 256, alpha, depth_multiplier,
+                                     stride = 2, block_id = 4)
+    x, depth = _depthwise_conv_block(x, depth, 256, alpha, depth_multiplier, block_id = 5)
+
+    x, depth = _depthwise_conv_block(x, depth, 512, alpha, depth_multiplier,
+                                     stride = 2, block_id = 6)
+    x, depth = _depthwise_conv_block(x, depth, 512, alpha, depth_multiplier, block_id = 7)
+    x, depth = _depthwise_conv_block(x, depth, 512, alpha, depth_multiplier, block_id = 8)
+    x, depth = _depthwise_conv_block(x, depth, 512, alpha, depth_multiplier, block_id = 9)
+    x, depth = _depthwise_conv_block(x, depth, 512, alpha, depth_multiplier, block_id = 10)
+    x, depth = _depthwise_conv_block(x, depth, 512, alpha, depth_multiplier, block_id = 11)
+
+    x, depth = _depthwise_conv_block(x, depth, 1024, alpha, depth_multiplier,
+                                     stride = 2, block_id = 12)
+    x, depth = _depthwise_conv_block(x, depth, 1024, alpha, depth_multiplier, block_id = 13)
+
+    x = GlobalAveragePooling2D(name="Global_avg_pool")(x)
+    x = OutputLayer(n=n_classes)(x)
+
+    model = Model(conn, inp, x, model_table)
+    model.compile()
+
+    return model
+
+
+def MobileNetV2(conn, model_table='MobileNetV2', n_classes=1000, n_channels=3, width=224, height=224,
+                norm_stds=(255*0.229, 255*0.224, 255*0.225), offsets=(255*0.485, 255*0.456, 255*0.406),
+                random_flip='none', random_crop='none', random_mutation='none', alpha=1):
+    '''
+    Generates a deep learning model with the MobileNetV2 architecture.
+    The implementation is revised based on https://github.com/keras-team/keras-applications/blob/master/keras_applications/mobilenet_v2.py
+
+    Parameters
+    ----------
+    conn : CAS
+        Specifies the CAS connection object.
+    model_table : string or dict or CAS table, optional
+        Specifies the CAS table to store the deep learning model.
+    n_classes : int, optional
+        Specifies the number of classes. If None is assigned, the model will
+        automatically detect the number of classes based on the training set.
+        Default: 1000
+    n_channels : int, optional
+        Specifies the number of the channels (i.e., depth) of the input layer.
+        Default: 3
+    width : int, optional
+        Specifies the width of the input layer.
+        Default: 32
+    height : int, optional
+        Specifies the height of the input layer.
+        Default: 32
+    norm_stds : double or iter-of-doubles, optional
+        Specifies a standard deviation for each channel in the input data.
+        The final input data is normalized with specified means and standard deviations.
+        Default: (255 * 0.229, 255 * 0.224, 255 * 0.225)
+    offsets : double or iter-of-doubles, optional
+        Specifies an offset for each channel in the input data. The final input
+        data is set after applying scaling and subtracting the specified offsets.
+        Default: (255*0.485, 255*0.456, 255*0.406)
+    random_flip : string, optional
+        Specifies how to flip the data in the input layer when image data is
+        used. Approximately half of the input data is subject to flipping.
+        Valid Values: 'h', 'hv', 'v', 'none'
+        Default: 'none'
+    random_crop : string, optional
+        Specifies how to crop the data in the input layer when image data is
+        used. Images are cropped to the values that are specified in the width
+        and height parameters. Only the images with one or both dimensions
+        that are larger than those sizes are cropped.
+        Valid Values: 'none', 'unique'
+        Default: 'none'
+    random_mutation : string, optional
+        Specifies how to apply data augmentations/mutations to the data in the input layer.
+        Valid Values: 'none', 'random'
+        Default: 'NONE'
+    alpha : int, optional
+        Specifies the width multiplier in the MobileNet paper
+        Default: 1
+
+    alpha : int, optional
+
+    Returns
+    -------
+    :class:`Model`
+
+    References
+    ----------
+    https://arxiv.org/abs/1801.04381
+
+    '''
+    def _make_divisible(v, divisor, min_value = None):
+        # make number of channel divisible
+        if min_value is None:
+            min_value = divisor
+        new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+        # Make sure that round down does not go down by more than 10%.
+        if new_v < 0.9 * v:
+            new_v += divisor
+        return new_v
+
+    def _inverted_res_block(inputs, in_channels, expansion, stride, alpha, filters, block_id):
+        """
+        Inverted Residual Block
+
+        Parameters
+        ----------
+        inputs:
+            Input tensor
+        in_channels:
+            Specifies the number of input tensor's channel
+        expansion:
+            expansion factor always applied to the input size.
+        stride:
+            the strides of the convolution
+        alpha:
+            width multiplier.
+        filters:
+            the dimensionality of the output space.
+        block_id:
+            block id used for naming layers
+
+        """
+        pointwise_conv_filters = int(filters * alpha)
+        pointwise_filters = _make_divisible(pointwise_conv_filters, 8)
+        x = inputs
+        prefix = 'block_{}_'.format(block_id)
+        n_groups = in_channels
+
+        if block_id:
+            # Expand
+            n_groups = expansion * in_channels
+            x = Conv2d(expansion * in_channels, 1, include_bias = False, act = 'identity',
+                       name = prefix + 'expand')(x)
+            x = BN(name = prefix + 'expand_BN', act = 'identity')(x)
+        else:
+            prefix = 'expanded_conv_'
+
+        # Depthwise
+        x = GroupConv2d(n_groups, n_groups, 3, stride = stride, act = 'identity',
+                        include_bias = False, name = prefix + 'depthwise')(x)
+        x = BN(name = prefix + 'depthwise_BN', act = 'relu')(x)
+
+        # Project
+        x = Conv2d(pointwise_filters, 1, include_bias = False, act = 'identity', name = prefix + 'project')(x)
+        x = BN(name = prefix + 'project_BN', act = 'identity')(x)
+
+        if in_channels == pointwise_filters and stride == 1:
+            return Res(name = prefix + 'add')([inputs, x]), pointwise_filters
+        return x, pointwise_filters
+
+    parameters = locals()
+    input_parameters = _get_layer_options(input_layer_options, parameters)
+    inp = Input(**input_parameters, name = 'data')
+    first_block_filters = _make_divisible(32 * alpha, 8)
+    x = Conv2d(first_block_filters, 3, stride = 2, include_bias = False, name = 'Conv1', act = 'identity')(inp)
+    x = BN(name = 'bn_Conv1', act='relu')(x)
+
+    x, n_channels = _inverted_res_block(x, first_block_filters, filters = 16, alpha = alpha, stride = 1,
+                                        expansion = 1, block_id = 0)
+
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 24, alpha = alpha, stride = 2,
+                                        expansion = 6, block_id = 1)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 24, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 2)
+
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 32, alpha = alpha, stride = 2,
+                                        expansion = 6, block_id = 3)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 32, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 4)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 32, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 5)
+
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 64, alpha = alpha, stride = 2,
+                                        expansion = 6, block_id = 6)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 64, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 7)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 64, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 8)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 64, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 9)
+
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 96, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 10)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 96, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 11)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 96, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 12)
+
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 160, alpha = alpha, stride = 2,
+                                        expansion = 6, block_id = 13)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 160, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 14)
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 160, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 15)
+
+    x, n_channels = _inverted_res_block(x, n_channels, filters = 320, alpha = alpha, stride = 1,
+                                        expansion = 6, block_id = 16)
+
+    # no alpha applied to last conv as stated in the paper:
+    # if the width multiplier is greater than 1 we increase the number of output channels
+    if alpha > 1.0:
+        last_block_filters = _make_divisible(1280 * alpha, 8)
+    else:
+        last_block_filters = 1280
+
+    x = Conv2d(last_block_filters, 1, include_bias = False, name = 'Conv_1', act = 'identity')(x)
+    x = BN(name = 'Conv_1_bn', act = 'relu')(x)
+
+    x = GlobalAveragePooling2D(name = "Global_avg_pool")(x)
+    x = OutputLayer(n = n_classes)(x)
+
+    model = Model(conn, inp, x, model_table)
+    model.compile()
+
+    return model
+
+
+def ShuffleNetV1(conn, model_table='ShuffleNetV1', n_classes=1000, n_channels=3, width=224, height=224,
+                 norm_stds=(255*0.229, 255*0.224, 255*0.225), offsets=(255*0.485, 255*0.456, 255*0.406),
+                 random_flip='none', random_crop='none', random_mutation='none', scale_factor=1.0,
+                 num_shuffle_units=[3, 7, 3], bottleneck_ratio=0.25, groups=3, block_act='identity'):
+    '''
+    Generates a deep learning model with the ShuffleNetV1 architecture.
+    The implementation is revised based on https://github.com/scheckmedia/keras-shufflenet/blob/master/shufflenet.py
+
+    Parameters
+    ----------
+    conn : CAS
+        Specifies the CAS connection object.
+    model_table : string or dict or CAS table, optional
+        Specifies the CAS table to store the deep learning model.
+    n_classes : int, optional
+        Specifies the number of classes. If None is assigned, the model will
+        automatically detect the number of classes based on the training set.
+        Default: 1000
+    n_channels : int, optional
+        Specifies the number of the channels (i.e., depth) of the input layer.
+        Default: 3
+    width : int, optional
+        Specifies the width of the input layer.
+        Default: 32
+    height : int, optional
+        Specifies the height of the input layer.
+        Default: 32
+    norm_stds : double or iter-of-doubles, optional
+        Specifies a standard deviation for each channel in the input data.
+        The final input data is normalized with specified means and standard deviations.
+        Default: (255 * 0.229, 255 * 0.224, 255 * 0.225)
+    offsets : double or iter-of-doubles, optional
+        Specifies an offset for each channel in the input data. The final input
+        data is set after applying scaling and subtracting the specified offsets.
+        Default: (255*0.485, 255*0.456, 255*0.406)
+    random_flip : string, optional
+        Specifies how to flip the data in the input layer when image data is
+        used. Approximately half of the input data is subject to flipping.
+        Valid Values: 'h', 'hv', 'v', 'none'
+        Default: 'none'
+    random_crop : string, optional
+        Specifies how to crop the data in the input layer when image data is
+        used. Images are cropped to the values that are specified in the width
+        and height parameters. Only the images with one or both dimensions
+        that are larger than those sizes are cropped.
+        Valid Values: 'none', 'unique'
+        Default: 'none'
+    random_mutation : string, optional
+        Specifies how to apply data augmentations/mutations to the data in the input layer.
+        Valid Values: 'none', 'random'
+        Default: 'NONE'
+    scale_factor : double
+
+    num_shuffle_units: iter-of-int, optional
+        number of stages (list length) and the number of shufflenet units in a
+        stage beginning with stage 2 because stage 1 is fixed
+        e.g. idx 0 contains 3 + 1 (first shuffle unit in each stage differs) shufflenet units for stage 2
+        idx 1 contains 7 + 1 Shufflenet Units for stage 3 and
+        idx 2 contains 3 + 1 Shufflenet Units
+        Default: [3, 7, 3]
+    bottleneck_ratio : double
+        bottleneck ratio implies the ratio of bottleneck channels to output channels.
+        For example, bottleneck ratio = 1 : 4 means the output feature map is 4 times
+        the width of the bottleneck feature map.
+    groups: int
+        Specifies the number of groups per channel
+        Default : 3
+    block_act : str
+        Specifies the activation function after depth-wise convolution and batch normalization layer
+        Default : 'identity'
+
+    Returns
+    -------
+    :class:`Model`
+
+    References
+    ----------
+    https://arxiv.org/pdf/1707.01083
+
+    '''
+
+    def _block(x, channel_map, bottleneck_ratio, repeat = 1, groups = 1, stage = 1):
+        """
+        creates a bottleneck block
+
+        Parameters
+        ----------
+        x:
+            Input tensor
+        channel_map:
+            list containing the number of output channels for a stage
+        repeat:
+            number of repetitions for a shuffle unit with stride 1
+        groups:
+            number of groups per channel
+        bottleneck_ratio:
+            bottleneck ratio implies the ratio of bottleneck channels to output channels.
+        stage:
+            stage number
+
+        Returns
+        -------
+        """
+        x = _shuffle_unit(x, in_channels = channel_map[stage - 2],
+                          out_channels = channel_map[stage - 1], strides = 2,
+                          groups = groups, bottleneck_ratio = bottleneck_ratio,
+                          stage = stage, block = 1)
+
+        for i in range(1, repeat + 1):
+            x = _shuffle_unit(x, in_channels = channel_map[stage - 1],
+                              out_channels = channel_map[stage - 1], strides = 1,
+                              groups = groups, bottleneck_ratio = bottleneck_ratio,
+                              stage = stage, block = (i + 1))
+
+        return x
+
+    def _shuffle_unit(inputs, in_channels, out_channels, groups, bottleneck_ratio, strides = 2, stage = 1, block = 1):
+        """
+        create a shuffle unit
+
+        Parameters
+        ----------
+        inputs:
+            Input tensor of with `channels_last` data format
+        in_channels:
+            number of input channels
+        out_channels:
+            number of output channels
+        strides:
+            An integer or tuple/list of 2 integers,
+        groups:
+            number of groups per channel
+        bottleneck_ratio: float
+            bottleneck ratio implies the ratio of bottleneck channels to output channels.
+        stage:
+            stage number
+        block:
+            block number
+
+        """
+        prefix = 'stage%d/block%d' % (stage, block)
+
+        # if strides >= 2:
+        # out_channels -= in_channels
+
+        # default: 1/4 of the output channel of a ShuffleNet Unit
+        bottleneck_channels = int(out_channels * bottleneck_ratio)
+        groups = (1 if stage == 2 and block == 1 else groups)
+
+        # x = _group_conv(inputs, in_channels, out_channels = bottleneck_channels,
+        #                 groups = (1 if stage == 2 and block == 1 else groups),
+        #                 name = '%s/1x1_gconv_1' % prefix)
+
+        x = GroupConv2d(bottleneck_channels, n_groups = (1 if stage == 2 and block == 1 else groups), act = 'identity',
+                        width = 1, height = 1, stride = 1, include_bias = False,
+                        name = '%s/1x1_gconv_1' % prefix)(inputs)
+
+        x = BN(act = 'relu', name = '%s/bn_gconv_1' % prefix)(x)
+
+        x = ChannelShuffle(n_groups = groups, name = '%s/channel_shuffle' % prefix)(x)
+        # depthwise convolutioin
+        x = GroupConv2d(x.shape[-1], n_groups = x.shape[-1], width = 3, height = 3, include_bias = False,
+                        stride = strides, act = 'identity',
+                        name = '%s/1x1_dwconv_1' % prefix)(x)
+        x = BN(act = block_act, name = '%s/bn_dwconv_1' % prefix)(x)
+
+        out_channels = out_channels if strides == 1 else out_channels - in_channels
+        x = GroupConv2d(out_channels, n_groups = groups, width = 1, height = 1, stride=1, act = 'identity',
+                        include_bias = False, name = '%s/1x1_gconv_2' % prefix)(x)
+
+        x = BN(act = block_act, name = '%s/bn_gconv_2' % prefix)(x)
+
+        if strides < 2:
+            ret = Res(act = 'relu', name = '%s/add' % prefix)([x, inputs])
+        else:
+            avg = Pooling(width = 3, height = 3, stride = 2, pool = 'mean', name = '%s/avg_pool' % prefix)(inputs)
+            ret = Concat(act = 'relu', name = '%s/concat' % prefix)([x, avg])
+
+        return ret
+
+    out_dim_stage_two = {1: 144, 2: 200, 3: 240, 4: 272, 8: 384}
+    exp = np.insert(np.arange(0, len(num_shuffle_units), dtype = np.float32), 0, 0)
+    out_channels_in_stage = 2 ** exp
+    out_channels_in_stage *= out_dim_stage_two[groups]  # calculate output channels for each stage
+    out_channels_in_stage[0] = 24  # first stage has always 24 output channels
+    out_channels_in_stage *= scale_factor
+    out_channels_in_stage = out_channels_in_stage.astype(int)
+
+    parameters = locals()
+    input_parameters = _get_layer_options(input_layer_options, parameters)
+    inp = Input(**input_parameters, name = 'data')
+
+    # create shufflenet architecture
+    x = Conv2d(out_channels_in_stage[0], 3, include_bias=False, stride=2, act="identity", name="conv1")(inp)
+    x = BN(act = 'relu', name = 'bn1')(x)
+    x = Pooling(width = 3, height = 3, stride=2, name="maxpool1")(x)
+
+    # create stages containing shufflenet units beginning at stage 2
+    for stage in range(0, len(num_shuffle_units)):
+        repeat = num_shuffle_units[stage]
+        x = _block(x, out_channels_in_stage, repeat=repeat,
+                   bottleneck_ratio=bottleneck_ratio,
+                   groups=groups, stage=stage + 2)
+
+    x = GlobalAveragePooling2D(name="Global_avg_pool")(x)
+    x = OutputLayer(n = n_classes)(x)
+
+    model = Model(conn, inputs=inp, outputs=x, model_table = model_table)
+    model.compile()
 
     return model
 

--- a/dlpy/applications.py
+++ b/dlpy/applications.py
@@ -279,7 +279,7 @@ def LeNet5(conn, model_table='LENET5', n_classes=10, n_channels=1, width=28, hei
         is used. Images are cropped to the values that are specified in the
         width and height parameters. Only the images with one or both
         dimensions that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final
@@ -354,7 +354,7 @@ def VGG11(conn, model_table='VGG11', n_classes=1000, n_channels=3, width=224, he
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final
@@ -441,7 +441,7 @@ def VGG13(conn, model_table='VGG13', n_classes=1000, n_channels=3, width=224, he
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -540,7 +540,7 @@ def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, he
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -685,7 +685,7 @@ def VGG19(conn, model_table='VGG19', n_classes=1000, n_channels=3, width=224, he
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -840,7 +840,7 @@ def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_clas
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -939,7 +939,7 @@ def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1039,7 +1039,7 @@ def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3,
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1137,7 +1137,7 @@ def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channe
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1240,7 +1240,7 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1342,7 +1342,7 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1498,7 +1498,7 @@ def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1598,7 +1598,7 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1754,7 +1754,7 @@ def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -1854,7 +1854,7 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -2019,7 +2019,7 @@ def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_o
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -2112,7 +2112,7 @@ def MobileNetV1(conn, model_table='MobileNetV1', n_classes=1000, n_channels=3, w
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
@@ -2143,7 +2143,8 @@ def MobileNetV1(conn, model_table='MobileNetV1', n_classes=1000, n_channels=3, w
 
     '''
     def _conv_block(inputs, filters, alpha, kernel = 3, stride = 1):
-        """Adds an initial convolution layer (with batch normalization
+        """
+        Adds an initial convolution layer (with batch normalization
 
         inputs:
             Input tensor
@@ -2206,6 +2207,9 @@ def MobileNetV1(conn, model_table='MobileNetV1', n_classes=1000, n_channels=3, w
     parameters = locals()
     input_parameters = _get_layer_options(input_layer_options, parameters)
     inp = Input(**input_parameters, name = 'data')
+    # the model down-sampled for 5 times by performing stride=2 convolution on
+    # conv_dw_1, conv_dw_2, conv_dw_4, conv_dw_6, conv_dw_12
+    # for each block, we use depthwise convolution with kernel=3 and point-wise convolution to save computation
     x, depth = _conv_block(inp, 32, alpha, stride = 2)
     x, depth = _depthwise_conv_block(x, depth, 64, alpha, depth_multiplier, block_id = 1)
 
@@ -2282,7 +2286,7 @@ def MobileNetV2(conn, model_table='MobileNetV2', n_classes=1000, n_channels=3, w
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
@@ -2357,7 +2361,7 @@ def MobileNetV2(conn, model_table='MobileNetV2', n_classes=1000, n_channels=3, w
 
         # Project
         x = Conv2d(pointwise_filters, 1, include_bias = False, act = 'identity', name = prefix + 'project')(x)
-        x = BN(name = prefix + 'project_BN', act = 'identity')(x)
+        x = BN(name = prefix + 'project_BN', act = 'identity')(x)  # identity activation on narrow tensor
 
         if in_channels == pointwise_filters and stride == 1:
             return Res(name = prefix + 'add')([inputs, x]), pointwise_filters
@@ -2366,6 +2370,10 @@ def MobileNetV2(conn, model_table='MobileNetV2', n_classes=1000, n_channels=3, w
     parameters = locals()
     input_parameters = _get_layer_options(input_layer_options, parameters)
     inp = Input(**input_parameters, name = 'data')
+    # compared with mobilenetv1, v2 introduces inverted residual structure.
+    # and Non-linearities in narrow layers are removed.
+    # inverted residual block does three convolutins: first is 1*1 convolution, second is depthwise convolution,
+    # third is 1*1 convolution but without any non-linearity
     first_block_filters = _make_divisible(32 * alpha, 8)
     x = Conv2d(first_block_filters, 3, stride = 2, include_bias = False, name = 'Conv1', act = 'identity')(inp)
     x = BN(name = 'bn_Conv1', act='relu')(x)
@@ -2475,7 +2483,7 @@ def ShuffleNetV1(conn, model_table='ShuffleNetV1', n_classes=1000, n_channels=3,
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
@@ -2693,7 +2701,7 @@ def DenseNet(conn, model_table='DenseNet', n_classes=None, conv_channel=16, grow
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -2785,7 +2793,7 @@ def DenseNet121(conn, model_table='DENSENET121', n_classes=1000, conv_channel=64
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input
@@ -2893,7 +2901,7 @@ def Darknet_Reference(conn, model_table='Darknet_Reference', n_classes=1000, act
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'unique'
 
     Returns
@@ -2991,7 +2999,7 @@ def Darknet(conn, model_table='Darknet', n_classes=1000, act='leaky', n_channels
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'unique'
 
     Returns
@@ -4019,7 +4027,7 @@ def InceptionV3(conn, model_table='InceptionV3',
         used. Images are cropped to the values that are specified in the width
         and height parameters. Only the images with one or both dimensions
         that are larger than those sizes are cropped.
-        Valid Values: 'none', 'unique'
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
         Default: 'none'
     offsets : double or iter-of-doubles, optional
         Specifies an offset for each channel in the input data. The final input

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -590,3 +590,25 @@ class TestApplications(unittest.TestCase):
                             anchor_ratio = anchor_ratio, anchor_scale = anchor_scale, coord_type = coord_type)
         self.assertTrue(model.layers[20].config == self.sample_syntax['faster_rcnn1'])
         model.print_summary()
+
+    def test_mobilenetv1(self):
+        from dlpy.applications import MobileNetV1
+        model = MobileNetV1(self.s, n_classes = 2, n_channels = 3, depth_multiplier = 10, alpha = 2)
+        self.assertTrue(len(model.layers) == 57)
+        self.assertTrue(model.layers[49]._output_size == (7, 7, 2048))
+        model.print_summary()
+
+    def test_mobilenetv2(self):
+        from dlpy.applications import MobileNetV2
+        model = MobileNetV2(self.s, n_classes = 2, n_channels = 3, alpha = 2)
+        self.assertTrue(len(model.layers) == 117)
+        self.assertTrue(model.layers[112]._output_size == (7, 7, 640))
+        model.print_summary()
+
+    def test_shufflenetv1(self):
+        from dlpy.applications import ShuffleNetV1
+        model = ShuffleNetV1(self.s, n_classes = 2, n_channels = 3, scale_factor=2, num_shuffle_units=[2, 2, 3, 4],
+                             bottleneck_ratio = 0.4, groups=2)
+        self.assertTrue(len(model.layers) == 130)
+        self.assertTrue(model.layers[127]._output_size == (4, 4, 3200))
+        model.print_summary()


### PR DESCRIPTION
The affected files include:
dlpy/applications.py: added mobilenetv1, mobilenetv2 and shufflenetv1
dlpy/tests/test_applications.py: test cases covering the model functions

A related example will be pushed in the next pull request.