### PR TITLE
fix the unit test problem. add number of channels check and convert.

### DIFF
--- a/dlpy/speech.py
+++ b/dlpy/speech.py
@@ -211,7 +211,15 @@ class Speech:
                              for segment_path_after_caslib in segment_path_after_caslib_list]
 
         # step 2: load audio
-        audio_table = AudioTable.load_audio_files(self.conn, path=listing_path_after_caslib, caslib=self.data_caslib)
+        try:
+            audio_table = AudioTable.load_audio_files(self.conn,
+                                                      path=listing_path_after_caslib, caslib=self.data_caslib)
+        except DLPyError as err:
+            if "cannot load audio files, something is wrong!" in str(err):
+                clean_audio(listing_path_local, segment_path_local_list)
+                raise DLPyError("Error: Cannot load the audio files. "
+                                "Please verify that \"data_path\" and \"local_path\" are pointing to the same position.")
+            raise err
 
         # step 3: extract features
         feature_table = AudioTable.extract_audio_features(self.conn, table=audio_table,


### PR DESCRIPTION
Ethem found a problem with test_speech.py. This happens when DLPY_DATA_DIR and DLPY_DATA_DIR_LOCAL don't point to the same position. Fixed.

Also push the change to check if the audio input has more than one channels. If the input is of stereo type, convert it to mono first.