### PR TITLE
Update to define better default for user-defined target labels

### DIFF
--- a/dlpy/tests/test_utils.py
+++ b/dlpy/tests/test_utils.py
@@ -20,6 +20,7 @@
 import unittest
 import swat
 import swat.utils.testing as tm
+import csv
 from dlpy.utils import *
 from dlpy.images import ImageTable
 
@@ -388,7 +389,71 @@ class TestUtils(unittest.TestCase):
         df = self.s.caslibinfo().CASLibInfo['Name']
         self.assertEqual(df[df == tmp_caslib].shape[0], 0)
 
+    def test_user_defined_labels(self):
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
 
+        server_type = get_cas_host_type(self.s).lower()
+
+        if server_type.startswith("lin") or server_type.startswith("osx"):
+            sep = '/'
+        else:
+            sep = '\\'
+            
+        # write user-defined label table to CSV file
+        levels = [
+                  '&', # : 0,
+                  'A', # : 1,
+                  'B', # : 2,
+                  'C', # : 3,
+                  'D', # : 4,
+                  'E', # : 5,
+                  'F', # : 6,
+                  'G', # : 7,
+                  'H', # : 8,
+                  'I', # : 9,
+                  'J', # : 10,
+                  'K', # : 11,
+                  'L', # : 12,
+                  'M', # : 13,
+                  'N', # : 14,
+                  'O', # : 15,
+                  'P', # : 16,
+                  'Q', # : 17,
+                  'R', # : 18,
+                  'S', # : 19,
+                  'T', # : 20,
+                  'U', # : 21,
+                  'V', # : 22,
+                  'W', # : 23,
+                  'X', # : 24,
+                  'Y', # : 25,
+                  'Z', # : 26,
+                  '\'', # : 27
+                  ' ', # : 28
+                ]
+
+        # save labels file to local data directory
+        header = ['label_id'] + ['label']
+
+        label_file_name = self.data_dir_local + sep + 'rnn_import_labels.csv'
+        with open(label_file_name, 'w+') as f:
+            writer = csv.writer(f, delimiter=',')
+            writer.writerow(header)
+
+            for ii, lval in enumerate(levels):
+                row = [str(ii)] + [lval]
+                writer.writerow(row)
+
+        # test using maximum label length in CSV to set uploaded table label length
+        label_table1 = get_user_defined_labels_table(self.s, label_file_name, None)
+
+        self.assertTrue(label_table1 is not None)
+
+        # test specifying label length to set uploaded table label length
+        label_table2 = get_user_defined_labels_table(self.s, label_file_name, 6)
+
+        self.assertTrue(label_table2 is not None)
 
 
 

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -392,12 +392,36 @@ def get_user_defined_labels_table(conn, label_file_name, label_length=None):
 
     full_filename = label_file_name
 
-    if label_length is None:
-        char_length = 200
-    else:
-        char_length = label_length
-    
-    labels = pd.read_csv(full_filename, skipinitialspace=True, index_col=False)
+    labels = pd.read_csv(full_filename, skipinitialspace=True, index_col=False, keep_default_na=False)
+
+    # make sure proper columns exist
+    if ('label' in labels.columns) and ('label_id' in labels.columns):
+        if label_length is None:
+
+            # check for columns that might be using space as label.  These labels would be
+            # ignored due to specifying skipinitialspace=True in Pandas read_csv function
+            for ii in range(labels.shape[0]):
+                if len(labels.loc[ii,'label']) == 0:
+                    labels.loc[ii,'label'] = " "
+
+            # set number of characters based on maximum label length
+            char_length = 0
+            warn_unequal_lengths = False
+            for ii in range(labels.shape[0]):
+                char_length = max([char_length, len(labels.loc[ii,'label'])])
+                if char_length != len(labels.loc[0,'label']):
+                    warn_unequal_lengths = True
+
+            if warn_unequal_lengths:
+                print('WARNING: not all target labels have the same length.'
+                      'Setting the label length to ' + char_length + ' characters.')
+
+        else:
+            char_label = label_length
+
+    else: 
+        raise DLPyError('The label table is missing one or both of the "label" and "label_id" columns.')
+
     conn.upload_frame(labels, casout=dict(name=temp_name, replace=True),
                       importoptions={'vars':[
                           {'name': 'label_id', 'type': 'int64'},

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -417,7 +417,7 @@ def get_user_defined_labels_table(conn, label_file_name, label_length=None):
                       'Setting the label length to ' + char_length + ' characters.')
 
         else:
-            char_label = label_length
+            char_length = label_length
 
     else: 
         raise DLPyError('The label table is missing one or both of the "label" and "label_id" columns.')


### PR DESCRIPTION
This small change will adaptive set the length for the CAS variable "label" to the largest number of characters in all the labels provided.  Thus if the "label" column contains the the values "AA", "BB", "C" and "#", the number of characters for all observations will be set to 2.  This is the solution for issue #203 .