### PR TITLE
support where clause in imagetable.show() and fix a bug to show()

### DIFF
--- a/dlpy/images.py
+++ b/dlpy/images.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from swat.cas.table import CASTable
 from .utils import random_name, image_blocksize, caslibify_context
+from warnings import warn
 
 
 class ImageTable(CASTable):
@@ -343,6 +344,8 @@ class ImageTable(CASTable):
             Specifies the size of the fig that contains the image.
         where : string, optional
             Specifies the SAS Where clause for selecting images to be shown.
+            One example is as follows:
+            my_images.show(nimages=2, where='_id_ eq 57')
 
         '''
 
@@ -350,8 +353,14 @@ class ImageTable(CASTable):
         # put where clause to select images
         self.params['where'] = where
         # restrict the number of observations to be shown
-        max_obs = self.numrows().numrows
-        nimages = min(max_obs, nimages)
+        try:
+            # we use numrows to check if where clause is valid
+            max_obs = self.numrows().numrows
+            nimages = min(max_obs, nimages)
+        except AttributeError:
+            self.params['where'] = None
+            warn("Where clause doesn't take effect, because encounter an error while processing where clause. "
+                 "Please check your where clause.")
 
         if randomize:
             temp_tbl = self.retrieve('image.fetchimages', _messagelevel='error',

--- a/dlpy/images.py
+++ b/dlpy/images.py
@@ -321,7 +321,7 @@ class ImageTable(CASTable):
 
         return out
 
-    def show(self, nimages=5, ncol=8, randomize=False, figsize=None):
+    def show(self, nimages=5, ncol=8, randomize=False, figsize=None, where=None):
 
         '''
 
@@ -339,12 +339,19 @@ class ImageTable(CASTable):
             columns in the plots.
         randomize : bool, optional
             Specifies whether to randomly choose the images for display.
-        figsize: int, optional
+        figsize : int, optional
             Specifies the size of the fig that contains the image.
+        where : string, optional
+            Specifies the SAS Where clause for selecting images to be shown.
 
         '''
 
         nimages = min(nimages, len(self))
+        # put where clause to select images
+        self.params['where'] = where
+        # restrict the number of observations to be shown
+        max_obs = self.numrows().numrows
+        nimages = min(max_obs, nimages)
 
         if randomize:
             temp_tbl = self.retrieve('image.fetchimages', _messagelevel='error',
@@ -358,6 +365,9 @@ class ImageTable(CASTable):
                                      sortby='random_index', to=nimages)
         else:
             temp_tbl = self._retrieve('image.fetchimages', to=nimages, image=self.running_image_column)
+
+        # remove the where clause
+        self.params['where'] = None
 
         if nimages > ncol:
             nrow = nimages // ncol + 1

--- a/dlpy/tests/test_imagetable.py
+++ b/dlpy/tests/test_imagetable.py
@@ -156,8 +156,6 @@ class TestImageTable(unittest.TestCase):
         self.assertTrue(int(out[5]) == 200)
         self.assertTrue(int(out[6]) == 200)
 
-
-
     def test_as_random_patches(self):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
@@ -206,3 +204,12 @@ class TestImageTable(unittest.TestCase):
         self.assertTrue(int(out[4]) == 200)
         self.assertTrue(int(out[5]) == 200)
         self.assertTrue(int(out[6]) == 200)
+
+    def test_show(self):
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+
+        img_path = self.data_dir+'giraffe_dolphin_small'
+        my_images = ImageTable.load_files(self.s, path=img_path)
+        # the test shold be clean, even if selected are less than nimages
+        my_images.show(nimages=2, where='_id_ eq 57')

--- a/dlpy/tests/test_imagetable.py
+++ b/dlpy/tests/test_imagetable.py
@@ -27,6 +27,7 @@ import unittest
 import swat
 import swat.utils.testing as tm
 from dlpy.images import ImageTable
+from dlpy.utils import DLPyError
 
 
 class TestImageTable(unittest.TestCase):
@@ -213,3 +214,13 @@ class TestImageTable(unittest.TestCase):
         my_images = ImageTable.load_files(self.s, path=img_path)
         # the test shold be clean, even if selected are less than nimages
         my_images.show(nimages=2, where='_id_ eq 57')
+
+    def test_show_invalid_whereclause(self):
+
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+
+        img_path = self.data_dir+'giraffe_dolphin_small'
+        my_images = ImageTable.load_files(self.s, path=img_path)
+        # the test shold be clean, even if where clause is invalid.
+        my_images.show(nimages=2, where='_idfe_ eq 57')


### PR DESCRIPTION
The changes will offer a flexible way to choose the images to be shown. Users write SAS where clause to make it. One example is dlpy/tests/test_imagetable.py test_show(). Besides, the push will fix a bug when nimages is greater than the number of observations.
