### PR TITLE
mix cnn and rnn connection support and other bugs fixed

### DIFF
--- a/dlpy/applications/yolo.py
+++ b/dlpy/applications/yolo.py
@@ -22,7 +22,7 @@ from dlpy.layers import InputLayer, Conv2d, BN, Pooling, Detection, Dense, Resha
 from dlpy.utils import DLPyError
 
 
-def YoloV2(conn, anchors, model_table='Tiny-Yolov2', n_channels=3, width=416, height=416, scale=1.0 / 255,
+def YoloV2(conn, anchors, model_table='YoloV2', n_channels=3, width=416, height=416, scale=1.0 / 255,
            random_mutation='NONE', act='leaky', act_detection='AUTO', softmax_for_class_prob=True,
            coord_type='YOLO', max_label_per_image=30, max_boxes=30,
            n_classes=20, predictions_per_grid=5, do_sqrt=True, grid_number=13,
@@ -216,7 +216,7 @@ def YoloV2(conn, anchors, model_table='Tiny-Yolov2', n_channels=3, width=416, he
     return model
 
 
-def YoloV2_MultiSize(conn, anchors, model_table='Tiny-Yolov2', n_channels=3, width=416, height=416, scale=1.0 / 255,
+def YoloV2_MultiSize(conn, anchors, model_table='YoloV2-MultiSize', n_channels=3, width=416, height=416, scale=1.0 / 255,
                      random_mutation='NONE', act='leaky', act_detection='AUTO', softmax_for_class_prob=True,
                      coord_type='YOLO', max_label_per_image=30, max_boxes=30,
                      n_classes=20, predictions_per_grid=5, do_sqrt=True, grid_number=13,
@@ -595,7 +595,7 @@ def Tiny_YoloV2(conn, anchors, model_table='Tiny-Yolov2', n_channels=3, width=41
     return model
 
 
-def YoloV1(conn, model_table='Yolov1', n_channels=3, width=448, height=448, scale=1.0 / 255,
+def YoloV1(conn, model_table='YoloV1', n_channels=3, width=448, height=448, scale=1.0 / 255,
            random_mutation='NONE', act='leaky', dropout=0, act_detection='AUTO', softmax_for_class_prob=True,
            coord_type='YOLO', max_label_per_image=30, max_boxes=30,
            n_classes=20, predictions_per_grid=2, do_sqrt=True, grid_number=7,
@@ -771,7 +771,7 @@ def YoloV1(conn, model_table='Yolov1', n_channels=3, width=448, height=448, scal
     return model
 
 
-def Tiny_YoloV1(conn, model_table='Tiny-Yolov1', n_channels=3, width=448, height=448, scale=1.0 / 255,
+def Tiny_YoloV1(conn, model_table='Tiny-YoloV1', n_channels=3, width=448, height=448, scale=1.0 / 255,
                 random_mutation='NONE', act='leaky', dropout=0, act_detection='AUTO', softmax_for_class_prob=True,
                 coord_type='YOLO', max_label_per_image=30, max_boxes=30,
                 n_classes=20, predictions_per_grid=2, do_sqrt=True, grid_number=7,

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -2133,7 +2133,7 @@ class Reshape(Layer):
     @property
     def output_size(self):
         if self._output_size is None:
-            self._output_size = (self.config['height'], self.config['width'], self.config['depth'])
+            self._output_size = (int(self.config['height']), int(self.config['width']), int(self.config['depth']))
         return self._output_size
 
     @property
@@ -2423,8 +2423,8 @@ class ROIPooling(Layer):
     @property
     def output_size(self):
         if self._output_size is None:
-            self._output_size = (self.config['output_width'], self.config['output_height'],
-                                 self.src_layers[0].output_size[1])
+            self._output_size = (int(self.config['output_width']), int(self.config['output_height']),
+                                 int(self.src_layers[0].output_size[1]))
         return self._output_size
 
     @property

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -338,7 +338,7 @@ class Layer(object):
             self.FLOPS = feature_map_size * self.src_layers[0].output_size[-1] * kernel_wh
         elif self.__class__ == GroupConv2d:
             kernel_wh = int(self.config['height']) * int(self.config['width'])
-            self.FLOPS = feature_map_size * self.src_layers[0].output_size[-1] * kernel_wh / self.n_groups
+            self.FLOPS = int(feature_map_size * self.src_layers[0].output_size[-1] * kernel_wh / self.n_groups)
         elif self.__class__ == Dense:
             self.FLOPS = self.num_weights
         else:

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -192,7 +192,8 @@ class Layer(object):
         layer_type = self.__class__.__name__
         if isinstance(inputs, list):
             if len(inputs) > 1 and layer_type not in ['Concat', 'Res', 'Scale', 'CLoss',
-                                                      'Dense', 'Model', 'OutputLayer', 'ROIPooling', 'FastRCNN']:
+                                                      'Dense', 'Model', 'OutputLayer', 'ROIPooling', 'FastRCNN',
+                                                      'Recurrent']:
                 raise DLPyError('The input of {} should have only one layer.'.format(layer_type))
         else:
             inputs = [inputs]
@@ -870,7 +871,6 @@ class GroupConv2d(Conv2d):
     @property
     def output_size(self):
         if self._output_size is None:
-            # calculate output according to specified padding
             # calculate output according to specified padding
             if self.padding != (None, None):
                 out_h = ((self.src_layers[0].output_size[0] - self.config['height'] + 2 * self.padding[0]) //

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -166,13 +166,13 @@ class Layer(object):
     can_be_last_layer = False
     number_of_instances = 0
     layer_id = None
-    shared_weights = None
 
     def __init__(self, name=None, config=None, src_layers=None):
         self.name = name
         self.config = config
         self.depth = None
         self._inbound_nodes = []
+        self.shared_weights = None
 
         if src_layers is None:
             self.src_layers = None
@@ -193,16 +193,17 @@ class Layer(object):
         if isinstance(inputs, list):
             if len(inputs) > 1 and layer_type not in ['Concat', 'Res', 'Scale', 'CLoss',
                                                       'Dense', 'Model', 'OutputLayer', 'ROIPooling', 'FastRCNN',
-                                                      'Recurrent']:
+                                                      'Recurrent', 'EmbeddingLoss']:
                 raise DLPyError('The input of {} should have only one layer.'.format(layer_type))
         else:
             inputs = [inputs]
         if layer_type == 'Model':
+            self.model_counter += 1
             copied_model = deepcopy(self)
             # update name
-            if copied_model.number_of_instances != 0:
+            if copied_model.model_counter > 1:
                 for layer in copied_model.layers:
-                    layer.name = layer.name + '_' + '{}'.format(copied_model.number_of_instances)
+                    layer.name = layer.name + '_' + '{}'.format(copied_model.model_counter)
             # share weights
             # for layer in copied_model.layers:
             #     layer.from_sub_network = self

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -109,6 +109,7 @@ class Network(Layer):
         self.target = None
         self.num_params = None
         self.count_instances()
+        self.model_counter = 0
 
     def _map_graph_network(self, inputs, outputs):
         '''
@@ -1263,10 +1264,15 @@ class Network(Layer):
         layers_name = [l.name for l in self.layers]
         for layer in layers:
             for anchor, shares in layer.items():
+                if anchor not in layers_name:
+                    raise DLPyError('{} is not in the model. Please check again.'.format(anchor))
                 if isinstance(shares, str):
                     shares = [shares]
                 for share in shares:
-                    idx_share = layers_name.index(share)
+                    try:
+                        idx_share = layers_name.index(share)
+                    except ValueError:
+                        raise DLPyError('{} is not in the model. Please check again.'.format(anchor))
                     self.layers[idx_share].shared_weights = anchor
 
     def save_to_astore(self, path = None, **kwargs):

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -654,18 +654,17 @@ class Network(Layer):
                             self.num_params += l.num_weights
                         if l.num_bias is not None:
                             self.num_params += l.num_bias
+                num_params_str = format(self.num_params, ",d")  # value with comma
 
                 total_FLOPS = 0
                 for l in self.layers:
                     if l.FLOPS:
                         total_FLOPS += l.FLOPS
+                total_FLOPS = format(total_FLOPS, ",d")  # value with comma
                 MB = 2**20
-                self.total_FLOPS_in_unit = round(total_FLOPS / MB, 3)  # MFLOPS
                 # total summary rows
                 total = pd.DataFrame([['', '', '', '', '', '', '', 'Total number of parameters', 'Total FLOPS'],
-                                      ['Summary', '', '', '', '', '', '', self.num_params, total_FLOPS],
-                                      ['In units', '', '', '', '', '', '', '', str(self.total_FLOPS_in_unit)+' MFLOPS']
-                                      ],
+                                      ['Summary', '', '', '', '', '', '', num_params_str, total_FLOPS]],
                                      columns=['Layer Id', 'Layer', 'Type', 'Kernel Size', 'Stride',
                                               'Activation', 'Output Size', 'Number of Parameters',
                                               'FLOPS(forward pass)'])

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -159,6 +159,9 @@ class Network(Layer):
 
     def compile(self):
         ''' parse the network nodes and process CAS Action '''
+        for l in self.layers:
+            if isinstance(l, Recurrent):
+                self.model_type = 'RNN'
         rt = self._retrieve_('deeplearn.buildmodel',
                              model=dict(name=self.model_name, replace=True), type=self.model_type)
 

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -629,7 +629,7 @@ class TestApplications(unittest.TestCase):
         self.assertTrue(len(model.layers) == 57)
         self.assertTrue(model.layers[49]._output_size == (7, 7, 2048))
         model.print_summary()
-        self.assertEqual(model.total_FLOPS_in_unit, 20932.283)
+        self.assertEqual(model.summary.iloc[7, -1], 36126720)
 
     def test_mobilenetv2(self):
         from dlpy.applications import MobileNetV2
@@ -655,7 +655,7 @@ class TestApplications(unittest.TestCase):
         # transpose conv print summary numerical check
         model = UNet(self.s, width = 256, height = 256, offsets = [1.25], scale = 0.0002)
         model.print_summary()
-        self.assertEqual(model.total_FLOPS_in_unit, 62316.0)
+        self.assertEqual(model.summary.iloc[23, -1], 4831838208)
 
     def test_unet_with_bn(self):
         from dlpy.applications import UNet

--- a/dlpy/tests/test_model.py
+++ b/dlpy/tests/test_model.py
@@ -943,7 +943,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(model.summary['Output Size'].values[-3], (1, 1, 1024))
         model.print_summary()
         # 2d print summary numerical check
-        self.assertEqual(model.total_FLOPS_in_unit, 6746.348)
+        self.assertEqual(model.summary.iloc[1, -1], 2985984)
 
     def test_heat_map_analysis(self):
         if self.data_dir is None:
@@ -1002,7 +1002,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(model_m.layers[3].output_size, (1, 80, 100))
         model_m.print_summary()
         # 1d print summary numerical check
-        self.assertEqual(model_m.total_FLOPS_in_unit, 54.855)
+        self.assertEqual(model_m.summary.iloc[1, -1], 240000)
 
     @classmethod
     def tearDownClass(cls):

--- a/dlpy/tests/test_network.py
+++ b/dlpy/tests/test_network.py
@@ -461,6 +461,30 @@ class TestNetwork(tm.TestCase):
         with self.assertRaises(DLPyError):
             model1.deploy(path='/amran/komran', output_format='astore')
 
+    def test_mix_cnn_rnn_network(self):
+        from dlpy.applications import ResNet50_Caffe
+        from dlpy import Sequential
+        from dlpy.blocks import Bidirectional
+        # the case is to test if CNN and RNN model can be connect using functional api
+        # the model_type is expected to be RNN in 19w47.
+        # CNN
+        model = ResNet50_Caffe(self.s)
+        cnn_head = model.to_functional_model(stop_layers = model.layers[-1])
+        # RNN
+        model_rnn = Sequential(conn = self.s, model_table = 'rnn')
+        model_rnn.add(Bidirectional(n = 100, n_blocks = 2))
+        model_rnn.add(OutputLayer())
+
+        f_rnn = model_rnn.to_functional_model()
+        # connecting
+        inp = Input(**cnn_head.layers[0].config)
+        x = cnn_head(inp)
+        y = f_rnn(x)
+        cnn_rnn = Model(self.s, inp, y)
+        cnn_rnn.compile()
+        # check type
+        self.assertTrue(cnn_rnn.model_type, 'RNN')
+
     @classmethod
     def tearDownClass(cls):
         # tear down tests


### PR DESCRIPTION
The push enables Recurrent layer to receive multiple inputs so that Functional API can be used for building mix CNN and RNN model in many usage cases. Besides, I add model_counter property for Model which reduces users load to change layers' name after several calls.
Some other changes include:
- correct YOLO model name
- remove the last row of print_summary
- error handlers for share_weights()
- test cases added and updated