### PR TITLE
Add reshape_after_input for resnet and vgg

### DIFF
--- a/dlpy/applications/resnet.py
+++ b/dlpy/applications/resnet.py
@@ -564,7 +564,7 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
 def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                    batch_norm_first=False, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
                    pre_trained_weights=False, pre_trained_weights_file=None, include_top=False,
-                   random_mutation=None, add_reshape_after_input=False):
+                   random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet50 architecture with convolution shortcut.
 
@@ -625,10 +625,8 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    add_reshape_after_input : bool, optional
+    reshape_after_input : Layer Reshape, optional
         Specifies whether to add a reshape layer after the input layer.
-        This option is required to build a RNN model that contains CNN layers.
-        Default: False
 
     Returns
     -------
@@ -657,8 +655,8 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
         # when a RNN model is built to consume the input data, it automatically flattens the input tensor
         # to a one-dimension vector. The reshape layer is required to reshape the tensor to the original definition.
         # This feature of mixing CNN layers with a RNN model is supported in VDMML 8.5.
-        if add_reshape_after_input:
-            model.add(Reshape(width=width, height=height, depth=n_channels))
+        if reshape_after_input:
+            model.add(reshape_after_input)
 
         # Top layers
         model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -708,7 +706,7 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
         model_cas = model_resnet50.ResNet50_Model(s=conn, model_table=model_table, n_channels=n_channels,
                                                   width=width, height=height, random_crop=random_crop, offsets=offsets,
                                                   random_flip=random_flip, random_mutation=random_mutation,
-                                                  add_reshape_after_input=add_reshape_after_input)
+                                                  reshape_after_input=reshape_after_input)
 
         if include_top:
             if n_classes != 1000:

--- a/dlpy/applications/resnet.py
+++ b/dlpy/applications/resnet.py
@@ -28,7 +28,7 @@ from .application_utils import get_layer_options, input_layer_options
 
 def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_classes=1000, n_channels=3, width=224,
                  height=224, scale=1, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
-                 random_mutation=None):
+                 random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet18 architecture.
 
@@ -80,6 +80,8 @@ def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_clas
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -100,6 +102,10 @@ def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_clas
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -135,7 +141,7 @@ def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_clas
 
 def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n_classes=1000, n_channels=3, width=224,
                    height=224, scale=1, random_flip=None, random_crop=None, offsets=None,
-                   random_mutation=None):
+                   random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet18 architecture with convolution shortcut.
 
@@ -184,6 +190,8 @@ def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -204,6 +212,10 @@ def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -240,7 +252,7 @@ def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n
 
 def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                  batch_norm_first=True, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
-                 random_mutation=None):
+                 random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet34 architecture.
 
@@ -292,6 +304,8 @@ def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3,
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -312,6 +326,10 @@ def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3,
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -347,7 +365,7 @@ def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3,
 
 def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                    batch_norm_first=False, random_flip=None, random_crop=None, offsets=None,
-                   random_mutation=None):
+                   random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet34 architecture with convolution shortcut.
 
@@ -397,6 +415,8 @@ def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channe
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -417,6 +437,10 @@ def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channe
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -454,7 +478,7 @@ def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channe
 
 def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                  batch_norm_first=True, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
-                 random_mutation=None):
+                 random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet50 architecture.
 
@@ -506,6 +530,8 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -526,6 +552,10 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -735,7 +765,7 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
 
 def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                   batch_norm_first=True, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
-                  random_mutation=None):
+                  random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet101 architecture.
 
@@ -788,6 +818,8 @@ def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -808,6 +840,10 @@ def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -844,7 +880,7 @@ def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels
 def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                     batch_norm_first=False, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
                     pre_trained_weights=False, pre_trained_weights_file=None, include_top=False,
-                    random_mutation=None):
+                    random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet101 architecture with convolution shortcut.
 
@@ -905,6 +941,8 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -929,6 +967,10 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
         # get the input parameters
         input_parameters = get_layer_options(input_layer_options, parameters)
         model.add(InputLayer(**input_parameters))
+
+        # add reshape when specified
+        if reshape_after_input:
+            model.add(reshape_after_input)
 
         # Top layers
         model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -977,7 +1019,8 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
         model_cas = model_resnet101.ResNet101_Model( s=conn, model_table=model_table, n_channels=n_channels,
                                                      width=width, height=height, random_crop=random_crop,
                                                      offsets=offsets,
-                                                     random_flip=random_flip, random_mutation=random_mutation)
+                                                     random_flip=random_flip, random_mutation=random_mutation,
+                                                     reshape_after_input=reshape_after_input)
 
         if include_top:
             if n_classes != 1000:
@@ -1005,7 +1048,7 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
 
 def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                   batch_norm_first=True, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
-                  random_mutation=None):
+                  random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the SAS ResNet152 architecture.
 
@@ -1058,6 +1101,8 @@ def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -1078,6 +1123,10 @@ def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -1114,7 +1163,7 @@ def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels
 def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                     batch_norm_first=False, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
                     pre_trained_weights=False, pre_trained_weights_file=None, include_top=False,
-                    random_mutation=None):
+                    random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the ResNet152 architecture with convolution shortcut
 
@@ -1175,6 +1224,8 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -1199,6 +1250,10 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
         # get the input parameters
         input_parameters = get_layer_options(input_layer_options, parameters)
         model.add(InputLayer(**input_parameters))
+
+        # add reshape when specified
+        if reshape_after_input:
+            model.add(reshape_after_input)
 
         # Top layers
         model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -1245,7 +1300,8 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
         model_cas = model_resnet152.ResNet152_Model( s=conn, model_table=model_table, n_channels=n_channels,
                                                      width=width, height=height, random_crop=random_crop,
                                                      offsets=offsets,
-                                                     random_flip=random_flip, random_mutation=random_mutation)
+                                                     random_flip=random_flip, random_mutation=random_mutation,
+                                                     reshape_after_input=reshape_after_input)
 
         if include_top:
             if n_classes != 1000:
@@ -1274,7 +1330,7 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
 def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_of_blocks=1, k=4, n_classes=None,
                 n_channels=3, width=32, height=32, scale=1, random_flip=None, random_crop=None,
                 offsets=(103.939, 116.779, 123.68),
-                random_mutation=None):
+                random_mutation=None, reshape_after_input=None):
     '''
     Generate a deep learning model with Wide ResNet architecture.
 
@@ -1336,6 +1392,8 @@ def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_o
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -1358,6 +1416,10 @@ def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_o
     # get the input parameters
     input_parameters = get_layer_options(input_layer_options, parameters)
     model.add(InputLayer(**input_parameters))
+
+    # add reshape when specified
+    if reshape_after_input:
+        model.add(reshape_after_input)
 
     # Top layers
     model.add(Conv2d(in_filters, 3, act='identity', include_bias=False, stride=1))

--- a/dlpy/applications/resnet.py
+++ b/dlpy/applications/resnet.py
@@ -19,7 +19,7 @@ import warnings
 
 from dlpy.sequential import Sequential
 from dlpy.model import Model
-from dlpy.layers import InputLayer, Conv2d, BN, Pooling, GlobalAveragePooling2D, OutputLayer
+from dlpy.layers import InputLayer, Conv2d, BN, Pooling, GlobalAveragePooling2D, OutputLayer, Reshape
 from dlpy.blocks import ResBlockBN, ResBlock_Caffe
 from dlpy.utils import DLPyError
 from dlpy.caffe_models import (model_resnet50, model_resnet101, model_resnet152)
@@ -564,7 +564,7 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
 def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
                    batch_norm_first=False, random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
                    pre_trained_weights=False, pre_trained_weights_file=None, include_top=False,
-                   random_mutation=None):
+                   random_mutation=None, add_reshape_after_input=False):
     '''
     Generates a deep learning model with the ResNet50 architecture with convolution shortcut.
 
@@ -625,6 +625,10 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    add_reshape_after_input : bool, optional
+        Specifies whether to add a reshape layer after the input layer.
+        This option is required to build a RNN model that contains CNN layers.
+        Default: False
 
     Returns
     -------
@@ -649,6 +653,12 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
         # get the input parameters
         input_parameters = get_layer_options(input_layer_options, parameters)
         model.add(InputLayer(**input_parameters))
+
+        # when a RNN model is built to consume the input data, it automatically flattens the input tensor
+        # to a one-dimension vector. The reshape layer is required to reshape the tensor to the original definition.
+        # This feature of mixing CNN layers with a RNN model is supported in VDMML 8.5.
+        if add_reshape_after_input:
+            model.add(Reshape(width=width, height=height, depth=n_channels))
 
         # Top layers
         model.add(Conv2d(64, 7, act='identity', include_bias=False, stride=2))
@@ -697,7 +707,8 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
 
         model_cas = model_resnet50.ResNet50_Model(s=conn, model_table=model_table, n_channels=n_channels,
                                                   width=width, height=height, random_crop=random_crop, offsets=offsets,
-                                                  random_flip=random_flip, random_mutation=random_mutation)
+                                                  random_flip=random_flip, random_mutation=random_mutation,
+                                                  add_reshape_after_input=add_reshape_after_input)
 
         if include_top:
             if n_classes != 1000:

--- a/dlpy/applications/resnet.py
+++ b/dlpy/applications/resnet.py
@@ -21,7 +21,7 @@ from dlpy.sequential import Sequential
 from dlpy.model import Model
 from dlpy.layers import InputLayer, Conv2d, BN, Pooling, GlobalAveragePooling2D, OutputLayer, Reshape
 from dlpy.blocks import ResBlockBN, ResBlock_Caffe
-from dlpy.utils import DLPyError
+from dlpy.utils import DLPyError, check_layer_class
 from dlpy.caffe_models import (model_resnet50, model_resnet101, model_resnet152)
 from .application_utils import get_layer_options, input_layer_options
 
@@ -80,7 +80,7 @@ def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_clas
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -93,6 +93,9 @@ def ResNet18_SAS(conn, model_table='RESNET18_SAS', batch_norm_first=True, n_clas
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -190,7 +193,7 @@ def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -203,6 +206,9 @@ def ResNet18_Caffe(conn, model_table='RESNET18_CAFFE', batch_norm_first=False, n
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -304,7 +310,7 @@ def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3,
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -317,6 +323,9 @@ def ResNet34_SAS(conn, model_table='RESNET34_SAS', n_classes=1000, n_channels=3,
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -415,7 +424,7 @@ def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channe
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -428,6 +437,9 @@ def ResNet34_Caffe(conn, model_table='RESNET34_CAFFE',  n_classes=1000, n_channe
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -530,7 +542,7 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -543,6 +555,9 @@ def ResNet50_SAS(conn, model_table='RESNET50_SAS', n_classes=1000, n_channels=3,
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -655,7 +670,7 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -672,8 +687,14 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
 
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
+
     # get all the parms passed in
     parameters = locals()
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     if not pre_trained_weights:
         model = Sequential(conn=conn, model_table=model_table)
@@ -818,7 +839,7 @@ def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -831,6 +852,9 @@ def ResNet101_SAS(conn, model_table='RESNET101_SAS',  n_classes=1000, n_channels
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -941,7 +965,7 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -957,6 +981,9 @@ def ResNet101_Caffe(conn, model_table='RESNET101_CAFFE', n_classes=1000, n_chann
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -1101,7 +1128,7 @@ def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -1114,6 +1141,9 @@ def ResNet152_SAS(conn, model_table='RESNET152_SAS',  n_classes=1000, n_channels
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -1224,7 +1254,7 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -1240,6 +1270,9 @@ def ResNet152_Caffe(conn, model_table='RESNET152_CAFFE',  n_classes=1000, n_chan
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     # get all the parms passed in
     parameters = locals()
@@ -1392,7 +1425,7 @@ def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_o
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -1405,6 +1438,9 @@ def ResNet_Wide(conn, model_table='WIDE_RESNET', batch_norm_first=True, number_o
 
     '''
     conn.retrieve('loadactionset', _messagelevel='error', actionset='deeplearn')
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     in_filters = 16
 

--- a/dlpy/applications/resnet.py
+++ b/dlpy/applications/resnet.py
@@ -655,6 +655,7 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
         # when a RNN model is built to consume the input data, it automatically flattens the input tensor
         # to a one-dimension vector. The reshape layer is required to reshape the tensor to the original definition.
         # This feature of mixing CNN layers with a RNN model is supported in VDMML 8.5.
+        # This option could be also used to reshape the input tensor.
         if reshape_after_input:
             model.add(reshape_after_input)
 

--- a/dlpy/applications/vgg.py
+++ b/dlpy/applications/vgg.py
@@ -225,7 +225,7 @@ def VGG13(conn, model_table='VGG13', n_classes=1000, n_channels=3, width=224, he
 def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, height=224, scale=1,
           random_flip=None, random_crop=None, offsets=(103.939, 116.779, 123.68),
           pre_trained_weights=False, pre_trained_weights_file=None, include_top=False,
-          random_mutation=None):
+          random_mutation=None, reshape_after_input=None):
     '''
     Generates a deep learning model with the VGG16 architecture.
 
@@ -278,6 +278,8 @@ def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, he
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -302,6 +304,9 @@ def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, he
         # get the input parameters
         input_parameters = get_layer_options(input_layer_options, parameters)
         model.add(InputLayer(**input_parameters))
+
+        if reshape_after_input:
+            model.add(reshape_after_input)
 
         model.add(Conv2d(n_filters=64, width=3, height=3, stride=1))
         model.add(Conv2d(n_filters=64, width=3, height=3, stride=1))
@@ -348,7 +353,7 @@ def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, he
 
         model_cas = model_vgg16.VGG16_Model(s=conn, model_table=model_table, n_channels=n_channels,
                                             width=width, height=height, random_crop=random_crop, offsets=offsets,
-                                            random_mutation=random_mutation)
+                                            random_mutation=random_mutation, reshape_after_input=reshape_after_input)
 
         if include_top:
             if n_classes != 1000:

--- a/dlpy/applications/vgg.py
+++ b/dlpy/applications/vgg.py
@@ -20,8 +20,8 @@ import warnings
 
 from dlpy.sequential import Sequential
 from dlpy.model import Model
-from dlpy.layers import InputLayer, Conv2d, BN, Pooling, OutputLayer, Dense
-from dlpy.utils import DLPyError
+from dlpy.layers import InputLayer, Conv2d, BN, Pooling, OutputLayer, Dense, Reshape
+from dlpy.utils import DLPyError, check_layer_class
 from dlpy.caffe_models import (model_vgg16, model_vgg19)
 from .application_utils import get_layer_options, input_layer_options
 
@@ -278,7 +278,7 @@ def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, he
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns
@@ -297,6 +297,9 @@ def VGG16(conn, model_table='VGG16', n_classes=1000, n_channels=3, width=224, he
 
     # get all the parms passed in
     parameters = locals()
+
+    # check the type
+    check_layer_class(reshape_after_input, Reshape)
 
     if not pre_trained_weights:
         model = Sequential(conn=conn, model_table=model_table)

--- a/dlpy/caffe_models/model_resnet101.py
+++ b/dlpy/caffe_models/model_resnet101.py
@@ -58,7 +58,7 @@ def ResNet101_Model(s, model_table='RESNET101', n_channels=3, width=224, height=
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns

--- a/dlpy/caffe_models/model_resnet101.py
+++ b/dlpy/caffe_models/model_resnet101.py
@@ -20,7 +20,8 @@ from ..utils import input_table_check
 
 def ResNet101_Model(s, model_table='RESNET101', n_channels=3, width=224, height=224,
                     random_crop=None, offsets=None,
-                    random_flip=None, random_mutation=None):
+                    random_flip=None, random_mutation=None,
+                    reshape_after_input=None):
     '''
     ResNet101 model definition
 
@@ -57,6 +58,8 @@ def ResNet101_Model(s, model_table='RESNET101', n_channels=3, width=224, height=
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -87,13 +90,20 @@ def ResNet101_Model(s, model_table='RESNET101', n_channels=3, width=224, height=
                                     randomcrop=random_crop, offsets=offsets,
                                     randomFlip=random_flip, randomMutation=random_mutation))
 
+    input_data_layer = 'data'
+    if reshape_after_input is not None:
+        input_data_layer = 'reshape1'
+        s.deepLearn.addLayer(model=model_table_opts, name='reshape1',
+                             layer=dict(type='reshape', **reshape_after_input.config),
+                             srcLayers=['data'])
+
     # -------------------- Layer 1 ----------------------
 
     # conv1 layer: 64 channels, 7x7 conv, stride=2; output = 112 x 112 */
     s.deepLearn.addLayer(model=model_table_opts, name='conv1',
                          layer=dict(type='convolution', nFilters=64, width=7, height=7,
                                     stride=2, act='identity'),
-                         srcLayers=['data'])
+                         srcLayers=[input_data_layer])
 
     # conv1 batch norm layer: 64 channels, output = 112 x 112 */
     s.deepLearn.addLayer(model=model_table_opts, name='bn_conv1',

--- a/dlpy/caffe_models/model_resnet152.py
+++ b/dlpy/caffe_models/model_resnet152.py
@@ -20,7 +20,8 @@ from ..utils import input_table_check
 
 def ResNet152_Model(s, model_table='RESNET152', n_channels=3, width=224, height=224,
                     random_crop=None, offsets=None,
-                    random_flip=None, random_mutation=None):
+                    random_flip=None, random_mutation=None,
+                    reshape_after_input=None):
     '''
     ResNet152 model definition
 
@@ -57,6 +58,8 @@ def ResNet152_Model(s, model_table='RESNET152', n_channels=3, width=224, height=
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -80,13 +83,20 @@ def ResNet152_Model(s, model_table='RESNET152', n_channels=3, width=224, height=
                                     randomcrop=random_crop, offsets=offsets,
                                     randomFlip=random_flip, randomMutation=random_mutation))
 
+    input_data_layer = 'data'
+    if reshape_after_input is not None:
+        input_data_layer = 'reshape1'
+        s.deepLearn.addLayer(model=model_table_opts, name='reshape1',
+                             layer=dict(type='reshape', **reshape_after_input.config),
+                             srcLayers=['data'])
+
     # -------------------- Layer 1 ----------------------
 
     # conv1 layer: 64 channels, 7x7 conv, stride=2; output = 112 x 112 */
     s.deepLearn.addLayer(model=model_table_opts, name='conv1',
                          layer=dict(type='convolution', nFilters=64, width=7, height=7,
                                     stride=2, act='identity'),
-                         srcLayers=['data'])
+                         srcLayers=[input_data_layer])
 
     # conv1 batch norm layer: 64 channels, output = 112 x 112 */
     s.deepLearn.addLayer(model=model_table_opts, name='bn_conv1',

--- a/dlpy/caffe_models/model_resnet50.py
+++ b/dlpy/caffe_models/model_resnet50.py
@@ -57,7 +57,7 @@ def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=22
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    reshape_after_input : Layer Reshape, optional
+    reshape_after_input : :class:`Reshape`, optional
         Specifies whether to add a reshape layer after the input layer.
 
     Returns

--- a/dlpy/caffe_models/model_resnet50.py
+++ b/dlpy/caffe_models/model_resnet50.py
@@ -20,7 +20,7 @@ from ..utils import input_table_check
 
 def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=224,
                    random_crop=None, offsets=None,
-                   random_flip=None, random_mutation=None, add_reshape_after_input=False):
+                   random_flip=None, random_mutation=None, reshape_after_input=None):
     '''
     ResNet50 model definition
 
@@ -57,10 +57,8 @@ def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=22
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
-    add_reshape_after_input : bool, optional
+    reshape_after_input : Layer Reshape, optional
         Specifies whether to add a reshape layer after the input layer.
-        This option is required to build a RNN model that contains CNN layers.
-        Default: False
 
     Returns
     -------
@@ -84,10 +82,10 @@ def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=22
                                     randomFlip=random_flip, randomMutation=random_mutation))
 
     input_data_layer = 'data'
-    if add_reshape_after_input:
-        input_data_layer='reshape1'
+    if reshape_after_input is not None:
+        input_data_layer = 'reshape1'
         s.deepLearn.addLayer(model=model_table_opts, name='reshape1',
-                             layer=dict(type='reshape',  width=width, height=height, depth=n_channels),
+                             layer=reshape_after_input.config,
                              srcLayers=['data'])
 
     # -------------------- Layer 1 ----------------------

--- a/dlpy/caffe_models/model_resnet50.py
+++ b/dlpy/caffe_models/model_resnet50.py
@@ -20,7 +20,7 @@ from ..utils import input_table_check
 
 def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=224,
                    random_crop=None, offsets=None,
-                   random_flip=None, random_mutation=None):
+                   random_flip=None, random_mutation=None, add_reshape_after_input=False):
     '''
     ResNet50 model definition
 
@@ -57,6 +57,11 @@ def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=22
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    add_reshape_after_input : bool, optional
+        Specifies whether to add a reshape layer after the input layer.
+        This option is required to build a RNN model that contains CNN layers.
+        Default: False
+
     Returns
     -------
     None
@@ -78,13 +83,20 @@ def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=22
                                     randomcrop=random_crop, offsets=offsets,
                                     randomFlip=random_flip, randomMutation=random_mutation))
 
+    input_data_layer = 'data'
+    if add_reshape_after_input:
+        input_data_layer='reshape1'
+        s.deepLearn.addLayer(model=model_table_opts, name='reshape1',
+                             layer=dict(type='reshape',  width=width, height=height, depth=n_channels),
+                             srcLayers=['data'])
+
     # -------------------- Layer 1 ----------------------
 
     # conv1 layer: 64 channels, 7x7 conv, stride=2; output = 112 x 112 */
     s.deepLearn.addLayer(model=model_table_opts, name='conv1',
                          layer=dict(type='convolution', nFilters=64, width=7, height=7,
                                     stride=2, act='identity'),
-                         srcLayers=['data'])
+                         srcLayers=[input_data_layer])
 
     # conv1 batch norm layer: 64 channels, output = 112 x 112 */
     s.deepLearn.addLayer(model=model_table_opts, name='bn_conv1',

--- a/dlpy/caffe_models/model_resnet50.py
+++ b/dlpy/caffe_models/model_resnet50.py
@@ -85,7 +85,7 @@ def ResNet50_Model(s, model_table='RESNET50', n_channels=3, width=224, height=22
     if reshape_after_input is not None:
         input_data_layer = 'reshape1'
         s.deepLearn.addLayer(model=model_table_opts, name='reshape1',
-                             layer=reshape_after_input.config,
+                             layer=dict(type='reshape', **reshape_after_input.config),
                              srcLayers=['data'])
 
     # -------------------- Layer 1 ----------------------

--- a/dlpy/caffe_models/model_vgg16.py
+++ b/dlpy/caffe_models/model_vgg16.py
@@ -20,7 +20,8 @@ from ..utils import input_table_check
 
 def VGG16_Model(s, model_table='VGG16', n_channels=3, width=224, height=224,
                 random_crop=None, offsets=None,
-                random_flip=None, random_mutation=None):
+                random_flip=None, random_mutation=None,
+                reshape_after_input=None):
     '''
     VGG16 model definition
 
@@ -57,6 +58,8 @@ def VGG16_Model(s, model_table='VGG16', n_channels=3, width=224, height=224,
     random_mutation : string, optional
         Specifies how to apply data augmentations/mutations to the data in the input layer.
         Valid Values: 'none', 'random'
+    reshape_after_input : Layer Reshape, optional
+        Specifies whether to add a reshape layer after the input layer.
 
     Returns
     -------
@@ -77,12 +80,19 @@ def VGG16_Model(s, model_table='VGG16', n_channels=3, width=224, height=224,
                          layer=dict(type='input', nchannels=n_channels, width=width, height=height,
                                     randomcrop=random_crop, offsets=offsets,
                                     randomFlip=random_flip, randomMutation=random_mutation))
+    # check whether add reshape
+    input_data_layer = 'data'
+    if reshape_after_input is not None:
+        input_data_layer = 'reshape1'
+        s.deepLearn.addLayer(model=model_table_opts, name='reshape1',
+                             layer=dict(type='reshape', **reshape_after_input.config),
+                             srcLayers=['data'])
 
     # conv1_1 layer: 64*3*3
     s.deepLearn.addLayer(model=model_table_opts, name='conv1_1',
                          layer=dict(type='convolution', nFilters=64, width=3, height=3,
                                     stride=1, act='relu'),
-                         srcLayers=['data'])
+                         srcLayers=[input_data_layer])
 
     # conv1_2 layer: 64*3*3
     s.deepLearn.addLayer(model=model_table_opts, name='conv1_2',

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -192,7 +192,8 @@ class Layer(object):
         layer_type = self.__class__.__name__
         if isinstance(inputs, list):
             if len(inputs) > 1 and layer_type not in ['Concat', 'Res', 'Scale', 'CLoss',
-                                                      'Dense', 'Model', 'OutputLayer', 'ROIPooling', 'FastRCNN']:
+                                                      'Dense', 'Model', 'OutputLayer', 'ROIPooling', 'FastRCNN',
+                                                      'Recurrent']:
                 raise DLPyError('The input of {} should have only one layer.'.format(layer_type))
         else:
             inputs = [inputs]

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -2097,6 +2097,9 @@ class Reshape(Layer):
         Specifies the depth of the feature maps.
     src_layers : iter-of-Layers, optional
         Specifies the layers directed to this layer.
+    order : string, optional
+        Specifies how to reshape the source layer.
+        Valid Values: AUTO, WHD, WDH, DWH, HWD, DHW, HDW
 
     Returns
     -------
@@ -2110,7 +2113,7 @@ class Reshape(Layer):
     number_of_instances = 0
 
     def __init__(self, name=None, act='AUTO', fcmp_act=None, width=None, height=None, depth=None, src_layers=None,
-                 **kwargs):
+                 order=None, **kwargs):
 
         if not __dev__ and len(kwargs) > 0:
             raise DLPyError('**kwargs can be used only in development mode.')

--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -2099,7 +2099,10 @@ class Reshape(Layer):
         Specifies the layers directed to this layer.
     order : string, optional
         Specifies how to reshape the source layer.
-        Valid Values: AUTO, WHD, WDH, DWH, HWD, DHW, HDW
+        Valid Values: AUTO, WHD, WDH, DWH, HWD, DHW, HDW. For AUTO, when the output channel is 1,
+        the reshape order is depth (D), width (W), and height (H).
+        When the output channel is evenly divisible by the input channel,
+        the reshape order is width (W), height (H), and depth (D).
 
     Returns
     -------

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -2973,9 +2973,6 @@ class Optimizer(DLPyDict):
     bn_src_layer_warnings : bool, optional
         Turns warning on or off, if batch normalization source layer has
         an atypical type, activation, or include_bias setting. Default: False
-        freeze_layers_to : string
-        Specifies a layer name to freeze this layer and all the layers before
-        this layer.
     total_mini_batch_size : int, optional
         specifies the number of observations in a mini-batch. You can use
         this parameter to control the number of observations that the action
@@ -3003,7 +3000,6 @@ class Optimizer(DLPyDict):
         this layer.
     freeze_batch_norm_stats : Boolean
         When set to True, freezes the statistics of all batch normalization layers.
-        Default : False
     freeze_layers : list of string
         Specifies a list of layer names whose trainable parameters will be frozen.
 
@@ -3016,7 +3012,7 @@ class Optimizer(DLPyDict):
                  dropout=0, dropout_input=0, dropout_type='standard', stagnation=0, threshold=0.00000001, f_conv=0,
                  snapshot_freq=0, log_level=0, bn_src_layer_warnings=True, freeze_layers_to=None, flush_weights=False,
                  total_mini_batch_size=None, mini_batch_buf_size=None,
-                 freeze_layers=None, freeze_batch_norm_stats=False):
+                 freeze_layers=None, freeze_batch_norm_stats=None):
         DLPyDict.__init__(self, algorithm=algorithm, mini_batch_size=mini_batch_size, seed=seed, max_epochs=max_epochs,
                           reg_l1=reg_l1, reg_l2=reg_l2, dropout=dropout, dropout_input=dropout_input,
                           dropout_type=dropout_type, stagnation=stagnation, threshold=threshold, f_conv=f_conv,

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -633,7 +633,16 @@ class Network(Layer):
                 l.layer_id = layer_ids[l.name.lower()]
 
     def print_summary(self):
-        ''' Display a table that summarizes the model architecture '''
+        '''
+
+        Display a table that summarizes the model architecture
+
+        Returns
+        -------
+        :pandas data frame
+
+        '''
+
         try:
             if len(self.layers) > 0 and self.layers[0].layer_id is None:
                 self.__load_layer_ids()
@@ -665,11 +674,15 @@ class Network(Layer):
                                      columns=['Layer Id', 'Layer', 'Type', 'Kernel Size', 'Stride',
                                               'Activation', 'Output Size', 'Number of Parameters',
                                               'FLOPS(forward pass)'])
-                display(pd.concat([layers_summary, total], ignore_index = True))
+                pd_layers = pd.concat([layers_summary, total], ignore_index = True)
+                display(pd_layers)
+                return pd_layers
             else:
                 display(self.summary)
+                return self.summary
         except ImportError:
             print(self.summary)
+            return self.summary
 
     def _repr_html_(self):
         return self.summary._repr_html_()

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -21,8 +21,8 @@
 import os
 
 from dlpy.layers import Layer
-from dlpy.utils import DLPyError, input_table_check, random_name, check_caslib, caslibify, get_server_path_sep,\
-    underscore_to_camelcase, caslibify_context
+from dlpy.utils import DLPyError, input_table_check, random_name, check_caslib, caslibify, get_server_path_sep, \
+    underscore_to_camelcase, caslibify_context, isnotebook
 from .layers import InputLayer, Conv2d, Pooling, BN, Res, Concat, Dense, OutputLayer, Keypoints, Detection, Scale,\
     Reshape, GroupConv2d, ChannelShuffle, RegionProposal, ROIPooling, FastRCNN, Conv2DTranspose, Recurrent
 import dlpy.model
@@ -678,13 +678,16 @@ class Network(Layer):
                                               'Activation', 'Output Size', 'Number of Parameters',
                                               'FLOPS(forward pass)'])
                 pd_layers = pd.concat([layers_summary, total], ignore_index = True)
-                display(pd_layers)
+                if not isnotebook():
+                    display(pd_layers)
                 return pd_layers
             else:
-                display(self.summary)
+                if not isnotebook():
+                    display(self.summary)
                 return self.summary
         except ImportError:
-            print(self.summary)
+            if not isnotebook():
+                print(self.summary)
             return self.summary
 
     def _repr_html_(self):

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -2270,6 +2270,8 @@ def extract_reshape_layer(layer_table):
     reshape_layer_config = dict()
     reshape_layer_config.update(get_num_configs(num_keys, 'reshapeopts', layer_table))
     reshape_layer_config.update(get_str_configs(str_keys, 'reshapeopts', layer_table))
+    if reshape_layer_config['act'] == 'Automatic':
+        reshape_layer_config['act'] = 'AUTO'
     reshape_layer_config['name'] = layer_table['_DLKey0_'].unique()[0]
     layer = Reshape(**reshape_layer_config)
     return layer

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -441,6 +441,13 @@ class TestApplications(unittest.TestCase):
         self.assertEqual(res.iloc[1, 6][1], 224)
         self.assertEqual(res.iloc[1, 6][2], 3)
 
+    # test resnet50 with the wrong reshape layer
+    def test_resnet50_4(self):
+        from dlpy.applications import ResNet50_Caffe
+
+        reshape = Pooling(width=2, height=2, stride=2)
+        self.assertRaises(DLPyError, lambda: ResNet50_Caffe(self.s, reshape_after_input=reshape))
+
     def test_resnet101(self):
         from dlpy.applications import ResNet101_SAS
         model = ResNet101_SAS(self.s)

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -416,6 +416,28 @@ class TestApplications(unittest.TestCase):
         model = ResNet50_Caffe(self.s)
         model.print_summary()
 
+    # test resnet50 with reshape
+    def test_resnet50_3(self):
+        from dlpy.applications import ResNet50_Caffe
+        model = ResNet50_Caffe(self.s, add_reshape_after_input=True)
+        model.print_summary()
+
+        # test it with pretrained weights
+        model1 = ResNet50_Caffe(self.s, model_table='Resnet50', n_classes=1000, n_channels=3,
+                                width=224, height=224, scale=1,
+                                offsets=None,
+                                random_crop='unique',
+                                random_flip='hv',
+                                random_mutation='random',
+                                pre_trained_weights=True,
+                                pre_trained_weights_file=self.data_dir + 'VGG_ILSVRC_16_layers.caffemodel.h5',
+                                include_top=True,
+                                add_reshape_after_input=True)
+        res = model1.print_summary()
+        self.assertEqual(res.iloc[1, 6][0], 224)
+        self.assertEqual(res.iloc[1, 6][1], 224)
+        self.assertEqual(res.iloc[1, 6][2], 3)
+
     def test_resnet101(self):
         from dlpy.applications import ResNet101_SAS
         model = ResNet101_SAS(self.s)
@@ -785,7 +807,7 @@ class TestApplications(unittest.TestCase):
         self.assertTrue(model.layers[12].output_size == (64, 64, 512))
         model.print_summary()
         # transpose conv print summary numerical check
-        model = UNet(self.s, width = 256, height = 256, offsets = [1.25], scale = 0.0002)
+        model = UNet(self.s, width=256, height=256, offsets=[1.25], scale=0.0002)
         model.print_summary()
         self.assertEqual(model.total_FLOPS_in_unit, 62316.0)
 

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -419,7 +419,10 @@ class TestApplications(unittest.TestCase):
     # test resnet50 with reshape
     def test_resnet50_3(self):
         from dlpy.applications import ResNet50_Caffe
-        model = ResNet50_Caffe(self.s, add_reshape_after_input=True)
+
+        #reshape = Reshape(width=224, height=224, depth=3, order='WHD')
+        reshape = Reshape(width=224, height=224, depth=3)
+        model = ResNet50_Caffe(self.s, reshape_after_input = reshape)
         model.print_summary()
 
         # test it with pretrained weights
@@ -430,10 +433,11 @@ class TestApplications(unittest.TestCase):
                                 random_flip='hv',
                                 random_mutation='random',
                                 pre_trained_weights=True,
-                                pre_trained_weights_file=self.data_dir + 'VGG_ILSVRC_16_layers.caffemodel.h5',
+                                pre_trained_weights_file=self.data_dir + 'ResNet-50-model.caffemodel.h5',
                                 include_top=True,
-                                add_reshape_after_input=True)
+                                reshape_after_input=reshape)
         res = model1.print_summary()
+        print(res)
         self.assertEqual(res.iloc[1, 6][0], 224)
         self.assertEqual(res.iloc[1, 6][1], 224)
         self.assertEqual(res.iloc[1, 6][2], 3)

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -420,9 +420,8 @@ class TestApplications(unittest.TestCase):
     def test_resnet50_3(self):
         from dlpy.applications import ResNet50_Caffe
 
-        #reshape = Reshape(width=224, height=224, depth=3, order='WHD')
-        reshape = Reshape(width=224, height=224, depth=3)
-        model = ResNet50_Caffe(self.s, reshape_after_input = reshape)
+        reshape = Reshape(width=224, height=224, depth=3, order='WHD')
+        model = ResNet50_Caffe(self.s, reshape_after_input=reshape)
         model.print_summary()
 
         # test it with pretrained weights

--- a/dlpy/tests/test_utils.py
+++ b/dlpy/tests/test_utils.py
@@ -467,4 +467,7 @@ class TestUtils(unittest.TestCase):
     def test_print_predefined_models(self):
         print_predefined_models()
 
-
+    def test_check_layer_type(self):
+        from dlpy.layers import Conv2DTranspose, Conv2d
+        layer = Conv2DTranspose(10)
+        self.assertRaises(DLPyError, lambda: check_layer_class(layer, Conv2d))

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -2430,7 +2430,7 @@ def print_predefined_models():
 
 def check_layer_class(layer_to_check, layer_class):
     if layer_to_check:
-        if layer_to_check.__class__ != layer_class:
+        if type(layer_to_check) != layer_class:
             raise DLPyError('The layer to be checked does not match '
                             'the layer class, {}.'.format(str(layer_class)))
 

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -2428,6 +2428,13 @@ def print_predefined_models():
     print('DLPy supports predefined models as follows: \n{}.'.format(', '.join(models_name)))
 
 
+def check_layer_class(layer_to_check, layer_class):
+    if layer_to_check:
+        if layer_to_check.__class__ != layer_class:
+            raise DLPyError('The layer to be checked does not match '
+                            'the layer class, {}.'.format(str(layer_class)))
+
+
 class DLPyDict(collections.MutableMapping):
     """ Dictionary that applies an arbitrary key-altering function before accessing the keys """
 


### PR DESCRIPTION
This allows to add a reshape layer after the input layer to reshape the input tensor.