### PR TITLE
MobileNetV2_ONNX and DenseNet121_ONNX support

### DIFF
--- a/dlpy/applications/densenet.py
+++ b/dlpy/applications/densenet.py
@@ -16,10 +16,15 @@
 #  limitations under the License.
 #
 
+import os
+
 from dlpy.sequential import Sequential
 from dlpy.layers import InputLayer, Conv2d, BN, Pooling, Concat, OutputLayer, GlobalAveragePooling2D
 from dlpy.blocks import DenseNetBlock
 from .application_utils import get_layer_options, input_layer_options
+from dlpy.model import Model
+from dlpy.utils import DLPyError
+from dlpy.network import extract_input_layer, extract_output_layer, extract_conv_layer
 
 
 def DenseNet(conn, model_table='DenseNet', n_classes=None, conv_channel=16, growth_rate=12, n_blocks=4,
@@ -240,5 +245,119 @@ def DenseNet121(conn, model_table='DENSENET121', n_classes=1000, conv_channel=64
 
     model.add(OutputLayer(act='softmax', n=n_classes))
 
+    return model
+
+
+def DenseNet121_ONNX(conn, model_file, n_classes=1000, width=224, height=224,
+                     offsets=(255*0.406, 255*0.456, 255*0.485), norm_stds=(255*0.225, 255*0.224, 255*0.229),
+                     random_flip=None, random_crop=None, random_mutation=None, include_top=False):
+    """
+    Generates a deep learning model with the DenseNet121_ONNX architecture.
+    The model architecture and pre-trained weights is generated from DenseNet121 ONNX trained on ImageNet dataset.
+    The model file and the weights file can be downloaded from https://support.sas.com/documentation/prod-p/vdmml/zip/.
+    To learn more information about the model and pre-processing.
+    Please go to the websites: https://github.com/onnx/models/tree/master/vision/classification/densenet-121.
+
+    Parameters
+    ----------
+    conn : CAS
+        Specifies the CAS connection object.
+    model_file : string
+        Specifies the absolute server-side path of the model table file.
+        The model table file can be downloaded from https://support.sas.com/documentation/prod-p/vdmml/zip/.
+    n_classes : int, optional
+        Specifies the number of classes.
+        Default: 1000
+    width : int, optional
+        Specifies the width of the input layer.
+        Default: 224
+    height : int, optional
+        Specifies the height of the input layer.
+        Default: 224
+    offsets : double or iter-of-doubles, optional
+        Specifies an offset for each channel in the input data. The final input
+        data is set after applying scaling and subtracting the specified offsets.
+        The channel order is BGR.
+        Default: (255*0.406, 255*0.456, 255*0.485)
+    norm_stds : double or iter-of-doubles, optional
+        Specifies a standard deviation for each channel in the input data.
+        The final input data is normalized with specified means and standard deviations.
+        The channel order is BGR.
+        Default: (255*0.225, 255*0.224, 255*0.229)
+    random_flip : string, optional
+        Specifies how to flip the data in the input layer when image data is
+        used. Approximately half of the input data is subject to flipping.
+        Valid Values: 'h', 'hv', 'v', 'none'
+    random_crop : string, optional
+        Specifies how to crop the data in the input layer when image data is
+        used. Images are cropped to the values that are specified in the width
+        and height parameters. Only the images with one or both dimensions
+        that are larger than those sizes are cropped.
+        Valid Values: 'none', 'unique', 'randomresized', 'resizethencrop'
+    random_mutation : string, optional
+        Specifies how to apply data augmentations/mutations to the data in the input layer.
+        Valid Values: 'none', 'random'
+    include_top : bool, optional
+        Specifies whether to include pre-trained weights of the top layers (i.e., the FC layers)
+        Default: False
+
+    """
+    parameters = locals()
+    input_parameters = get_layer_options(input_layer_options, parameters)
+
+    # load model and model weights
+    model = Model.from_sashdat(conn, path = model_file)
+    # check if a user points to a correct model.
+    if model.summary.shape[0] != 307:
+        raise DLPyError("The model file doesn't point to a valid DenseNet121_ONNX model. "
+                        "Please check the SASHDAT file.")
+    # extract input layer config
+    model_table_df = conn.CASTable(**model.model_table).to_frame()
+    input_layer_df = model_table_df[model_table_df['_DLLayerID_'] == 0]
+    input_layer = extract_input_layer(input_layer_df)
+    input_layer_config = input_layer.config
+    # update input layer config
+    input_layer_config.update(input_parameters)
+    # update the layer list
+    model.layers[0] = InputLayer(**input_layer_config, name=model.layers[0].name)
+
+    # warning if model weights doesn't exist
+    if not conn.tableexists(model.model_weights.name).exists:
+        weights_file_path = os.path.join(os.path.dirname(model_file), model.model_name + '_weights.sashdat')
+        print('WARNING: Model weights is not attached '
+              'since system cannot find a weights file located at {}'.format(weights_file_path))
+
+    if include_top:
+        if n_classes != 1000:
+            raise DLPyError("If include_top is enabled, n_classes has to be 1000.")
+    else:
+        # since the output layer is non fully connected layer,
+        # we need to modify the convolution right before the output. The number of filter is set to n_classes.
+        conv_layer_df = model_table_df[model_table_df['_DLLayerID_'] == 305]
+        conv_layer = extract_conv_layer(conv_layer_df)
+        conv_layer_config = conv_layer.config
+        # update input layer config
+        conv_layer_config.update({'n_filters': n_classes})
+        # update the layer list
+        model.layers[-2] = Conv2d(**conv_layer_config,
+                                  name=model.layers[-2].name, src_layers=model.layers[-3])
+
+        # overwrite n_classes in output layer
+        out_layer_df = model_table_df[model_table_df['_DLLayerID_'] == 306]
+        out_layer = extract_output_layer(out_layer_df)
+        out_layer_config = out_layer.config
+        # update input layer config
+        out_layer_config.update({'n': n_classes})
+        # update the layer list
+        model.layers[-1] = OutputLayer(**out_layer_config,
+                                       name = model.layers[-1].name, src_layers=model.layers[-2])
+
+        # remove top weights
+        model.model_weights.append_where('_LayerID_<305')
+        model._retrieve_('table.partition', table=model.model_weights,
+                         casout=dict(replace=True, name=model.model_weights.name))
+        model.set_weights(model.model_weights.name)
+    # recompile the whole network according to the new layer list
+    model.compile()
     return model
 

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -168,10 +168,6 @@ class Network(Layer):
         rt = self._retrieve_('deeplearn.buildmodel',
                              model=dict(name=self.model_name, replace=True), type=self.model_type)
 
-        if not all(x.can_be_last_layer for x in self.output_layers):
-            raise DLPyError('Output layers can only be {}' \
-                            .format([i.__name__ for i in Layer.__subclasses__() if i.can_be_last_layer]))
-
         if rt.severity > 1:
             raise DLPyError('cannot build model, there seems to be a problem.')
         self.num_params = 0
@@ -208,7 +204,7 @@ class Network(Layer):
             option = layer.to_model_params()
             rt = self._retrieve_('deeplearn.addlayer', model = self.model_name, **option)
             if rt.severity > 1:
-                raise DLPyError('there seems to be an error while adding the ' + layer.name + '.')
+                raise DLPyError('there seems to be an error while adding the ' + str(layer.name) + '.')
             if layer.num_weights is None:
                 num_weights = 0
             else:
@@ -2233,6 +2229,9 @@ def extract_residual_layer(layer_table):
 
     res_layer_config.update(get_str_configs(['act'], 'residualopts', layer_table))
     res_layer_config['name'] = layer_table['_DLKey0_'].unique()[0]
+    # manually correct table content as a valid option
+    if res_layer_config['act'] == 'Automatic':
+        res_layer_config['act'] = 'AUTO'
 
     layer = Res(**res_layer_config)
     return layer

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -853,3 +853,64 @@ class TestApplications(unittest.TestCase):
         self.assertTrue(len(model.layers) == 33 + 9 * 2)
         self.assertTrue(model.layers[12].output_size == (256, 256, 256))
         model.print_summary()
+
+    def test_mobilenetv2_onnx_1(self):
+        from dlpy.applications import MobileNetV2_ONNX
+
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+        file_dependency = self.data_dir + 'MobileNetV2_ONNX.sashdat'
+        if not file_exist_on_server(self.s, file_dependency):
+            unittest.TestCase.skipTest(self, "File, {}, not found.".format(file_dependency))
+
+        model = MobileNetV2_ONNX(self.s,
+                                 model_file=file_dependency,
+                                 width=224, height=224,
+                                 n_classes=10, include_top=False)
+        model.print_summary()
+
+    def test_mobilenetv2_onnx_2(self):
+        from dlpy.applications import MobileNetV2_ONNX
+
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+        file_dependency = self.data_dir + 'MobileNetV2_ONNX.sashdat'
+        if not file_exist_on_server(self.s, file_dependency):
+            unittest.TestCase.skipTest(self, "File, {}, not found.".format(file_dependency))
+
+        model = MobileNetV2_ONNX(self.s,
+                                 model_file=file_dependency,
+                                 width=224, height=224,
+                                 n_classes=1000, include_top=True)
+        model.print_summary()
+
+    def test_densenet121_onnx_1(self):
+        from dlpy.applications import DenseNet121_ONNX
+
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+        file_dependency = self.data_dir + 'DenseNet121_ONNX.sashdat'
+        file_dependency = '/cas/DeepLearn/models/DenseNet121_ONNX/DenseNet121_ONNX.sashdat'
+        if not file_exist_on_server(self.s, file_dependency):
+            unittest.TestCase.skipTest(self, "File, {}, not found.".format(file_dependency))
+
+        model = DenseNet121_ONNX(self.s,
+                                 model_file='/cas/DeepLearn/weshiz/onnx/image_classification/densenet121.sashdat',
+                                 width=224, height=224,
+                                 n_classes=10, include_top=False)
+        model.print_summary()
+
+    def test_densenet121_onnx_2(self):
+        from dlpy.applications import DenseNet121_ONNX
+
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+        file_dependency = self.data_dir + 'DenseNet121_ONNX.sashdat'
+        if not file_exist_on_server(self.s, file_dependency):
+            unittest.TestCase.skipTest(self, "File, {}, not found.".format(file_dependency))
+
+        model = DenseNet121_ONNX(self.s,
+                                 model_file=file_dependency,
+                                 width=224, height=224,
+                                 n_classes=1000, include_top=True)
+        model.print_summary()

--- a/dlpy/tests/test_applications.py
+++ b/dlpy/tests/test_applications.py
@@ -890,12 +890,11 @@ class TestApplications(unittest.TestCase):
         if self.data_dir is None:
             unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
         file_dependency = self.data_dir + 'DenseNet121_ONNX.sashdat'
-        file_dependency = '/cas/DeepLearn/models/DenseNet121_ONNX/DenseNet121_ONNX.sashdat'
         if not file_exist_on_server(self.s, file_dependency):
             unittest.TestCase.skipTest(self, "File, {}, not found.".format(file_dependency))
 
         model = DenseNet121_ONNX(self.s,
-                                 model_file='/cas/DeepLearn/weshiz/onnx/image_classification/densenet121.sashdat',
+                                 model_file=file_dependency,
                                  width=224, height=224,
                                  n_classes=10, include_top=False)
         model.print_summary()

--- a/dlpy/tests/test_network.py
+++ b/dlpy/tests/test_network.py
@@ -97,21 +97,6 @@ class TestNetwork(tm.TestCase):
             output1 = OutputLayer(2)(conv1)
             Model(conn=self.s, inputs=[conv1], outputs=[output1])
 
-    def test_outputs(self):
-        with self.assertRaises(DLPyError):
-            input1 = Input(n_channels=1, width=28, height=28)
-            conv1 = Conv2d(2)(input1)
-            model1 = Model(conn=self.s, inputs=[input1], outputs=[conv1])
-            model1.compile()
-
-        with self.assertRaises(DLPyError):
-            input1 = Input(n_channels=1, width=28, height=28)
-            conv1 = Conv2d(2)(input1)
-            conv2 = BN()(input1)
-            output1 = OutputLayer(2)(conv1)
-            model1 = Model(conn=self.s, inputs=[input1], outputs=[conv2, output1])
-            model1.compile()
-
     def test_without_variable(self):
         input1 = Input(n_channels=1, width=28, height=28)
         conv1 = Conv2d(2)(Conv2d(2)(input1))


### PR DESCRIPTION
The push includes changes as follows:
1. Support MobileNetV2_ONNX and DenseNet121_ONNX: The reason I create a new function for each of them is that those models are not identical to mobilenetv2 or densenet121. Essentially, the function takes the path of the model file and loads model table and model weights table if possible.
Model files, weights files, and readme files are put into /cas/DeepLearn/models/DenseNet121_ONNX and /cas/DeepLearn/models/MobileNetV2_ONNX.
2. Test cases for the two models.
3. Minor changes in dlpy/network.py. One place is to remove self.output_layers checking. It is unnecessary and will cause an attribute error when a model built by load() is compiled. Another place is to change 'Automatic' to 'auto' as a valid option. 