### PR TITLE
Force return of special tokens mask

### DIFF
--- a/dlpy/transformers/bert_model.py
+++ b/dlpy/transformers/bert_model.py
@@ -33,9 +33,19 @@ try:
     from transformers import BertTokenizer, BertModel, BertConfig
     from transformers import RobertaTokenizer, RobertaModel, RobertaConfig
     from transformers import DistilBertTokenizer, DistilBertModel, DistilBertConfig
+    
+    from distutils.version import StrictVersion
+    import pkg_resources
+    import warnings
+    if StrictVersion(pkg_resources.get_distribution("transformers").version) > '2.3.0':
+        warn_message = ("You are using a version of the transformers package ("
+                        + pkg_resources.get_distribution("transformers").version + 
+                        ") that has not been tested for compatibility.  Unexpected behavior "
+                        "may occur.")
+        warnings.warn(warn_message,UserWarning)
 except:
-    raise DLPyError("Unable to import from transformers."
-                    "Please install transformers and try again.")
+    raise DLPyError("Unable to import from transformers.  Please install "
+                    "a supported version (2.3.0 or earlier) and try again.")
 
 try:
     import h5py

--- a/dlpy/transformers/bert_utils.py
+++ b/dlpy/transformers/bert_utils.py
@@ -648,6 +648,7 @@ def bert_prepare_data(conn, tokenizer, max_seq_len, input_a, segment_vocab_size=
         txt_encoding = tokenizer.encode_plus(txt_a,
                                              text_pair=txt_b,
                                              add_special_tokens=True,
+                                             return_special_tokens_mask=True,
                                              max_length=max_seq_len)
         tmp_tokenized_text = tokenizer.convert_ids_to_tokens(txt_encoding['input_ids'])
         


### PR DESCRIPTION
This pull forces the encode_plus() function to return the special tokens mask that is used for BERT data preparation.  There is also a new warning message to indicate to the user whether the DLPy team has tested for compatibility with the version of the transformers package that the user has installed.