### PR TITLE
Fix bugs in ResNet50_Caffe and recordSeed.

### DIFF
--- a/dlpy/applications/resnet.py
+++ b/dlpy/applications/resnet.py
@@ -772,7 +772,7 @@ def ResNet50_Caffe(conn, model_table='RESNET50_CAFFE', n_classes=1000, n_channel
             model = Model.from_table(model_cas, display_note=False)
             model.load_weights(path=pre_trained_weights_file)
             model._retrieve_('deeplearn.removelayer', model=model_table, name='fc1000')
-            model._retrieve_('deeplearn.addlayer', model=model_table, name='output',
+            model._retrieve_('deeplearn.addlayer', model=model_table, name='fc1000',
                              layer=dict(type='output', n=n_classes, act='softmax'),
                              srcLayers=['pool5'])
 

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -699,6 +699,10 @@ class Model(Network):
                               force_equal_padding=force_equal_padding, data_specs=data_specs, n_threads=n_threads,
                               target_order=target_order)
 
+        # the recordSeed option must not be specified in order to disable it, contrary to the Viya documentation
+        if (record_seed == 0) or (record_seed == None):
+            parameters.__delitem__("record_seed")
+
         rt = self._retrieve_('deeplearn.dltrain', message_level='note', **parameters)
 
         if rt.severity < 2:

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -700,8 +700,8 @@ class Model(Network):
                               target_order=target_order)
 
         # the recordSeed option must not be specified in order to disable it, contrary to the Viya documentation
-        if (record_seed == 0) or (record_seed == None):
-            parameters.__delitem__("record_seed")
+        if record_seed == 0 or record_seed == None:
+            del parameters['record_seed']
 
         rt = self._retrieve_('deeplearn.dltrain', message_level='note', **parameters)
 
@@ -1717,8 +1717,8 @@ class Model(Network):
         comm = Comm(target_name='%(plot_id)s_comm' % dict(plot_id='foo'))
         
         # the recordSeed option must not be specified in order to disable it, contrary to the Viya documentation
-        if (record_seed == 0) or (record_seed == None):
-            parameters.__delitem__("record_seed")
+        if record_seed == 0 or record_seed == None:
+            del parameters['record_seed']
 
         with swat.option_context(print_messages=False):
             self._retrieve_('deeplearn.dltrain', message_level='note',

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -1715,6 +1715,10 @@ class Model(Network):
         import swat
         from ipykernel.comm import Comm
         comm = Comm(target_name='%(plot_id)s_comm' % dict(plot_id='foo'))
+        
+        # the recordSeed option must not be specified in order to disable it, contrary to the Viya documentation
+        if (record_seed == 0) or (record_seed == None):
+            parameters.__delitem__("record_seed")
 
         with swat.option_context(print_messages=False):
             self._retrieve_('deeplearn.dltrain', message_level='note',

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -700,7 +700,7 @@ class Model(Network):
                               target_order=target_order)
 
         # the recordSeed option must not be specified in order to disable it, contrary to the Viya documentation
-        if record_seed == 0 or record_seed == None:
+        if record_seed == 0 or record_seed is None:
             del parameters['record_seed']
 
         rt = self._retrieve_('deeplearn.dltrain', message_level='note', **parameters)
@@ -1717,7 +1717,7 @@ class Model(Network):
         comm = Comm(target_name='%(plot_id)s_comm' % dict(plot_id='foo'))
         
         # the recordSeed option must not be specified in order to disable it, contrary to the Viya documentation
-        if record_seed == 0 or record_seed == None:
+        if record_seed == 0 or record_seed is None:
             del parameters['record_seed']
 
         with swat.option_context(print_messages=False):


### PR DESCRIPTION
Small bug fixes:

The ResNet50_Caffe model by default removes the ImageNet-trained output layer and replaces it with a similar layer with untrained parameters.  The name of the layer changes though, and this creates problems for the internal model representation on the Viya server side.  

If specified, the record_seed parameter causes random selection of records for each mini-batch.  We use a default value of 0, which means that the record_seed option is always used.  The fix overrides the default so the option is processed correctly by the deep learning actions.