### PR TITLE
updated create_object_detection_table_no_xml to allow bounding box restrictions

### DIFF
--- a/dlpy/tests/test_utils.py
+++ b/dlpy/tests/test_utils.py
@@ -173,6 +173,20 @@ class TestUtils(unittest.TestCase):
         # check if the output size is correct
         self.assertEqual(self.s.image.summarizeimages('output').Summary.values[0][6], 416)
         self.assertEqual(self.s.image.summarizeimages('output').Summary.values[0][7], 512)
+              
+    def test_create_object_detection_table_no_xml_verification(self):
+        # make sure that txt files are already in self.data_dir + 'dlpy_obj_det_test', otherwise the test will fail.
+        if self.data_dir is None:
+            unittest.TestCase.skipTest(self, "DLPY_DATA_DIR is not set in the environment variables")
+        
+        create_object_detection_table_no_xml2(self.s, data_path=self.data_dir + 'dlpy_obj_det_test', coord_type='yolo', 
+                                             output='output', annotation_path=self.data_dir + 'dlpy_obj_det_test',
+                                             image_size=(416, 416), check_bbox=True, min_bbox_width=35, min_bbox_height=35, 
+                                             min_bbox_x=0, min_bbox_y=0, max_bbox_x=None, max_bbox_y=None)
+        # CAS Table should only contain objects whose bounding boxes meet user criteria
+        # Based on this criteria and given the test data, only 3 images with a total of 5 objects should remain
+        a = self.s.CASTable('output')
+        self.assertEqual(len(a), 3)
 
     def test_get_anchors(self):
         if platform.system().startswith('Win'):


### PR DESCRIPTION
I've updated the create_object_detection_table_no_xml function to allow users to define various criteria for selecting bounding boxes. (only yolo format currently supported)
If "check_bbox" is set to true, bounding boxes that don't meet the users criteria are excluded.

Following criteria can be defined:
     **min_bbox_width** : integer, optional
        Specifies the minimum width for bounding boxes after image resizing.
        All bounding boxes below this threshold will be dropped.
        Default : 1
    **min_bbox_height** : integer, optional
        Specifies the minimum height for bounding boxes after image resizing.
        All bounding boxes below this threshold will be dropped.
        Default : 1
    **min_bbox_x** : integer, optional
        Specifies the minimum x1 value for bounding boxes after image resizing.
        All bounding boxes below this threshold will be dropped.
        Helps in dropping bounding boxes outside of the image.
        Default : 0
    **min_bbox_y** : integer, optional
        Specifies the minimum y1 value for bounding boxes after image resizing.
        All bounding boxes below this threshold will be dropped.
        Helps in dropping bounding boxes outside of the image.
        Default : 0
    **max_bbox_x** : integer, optional
        Specifies the minimum x2 value for bounding boxes after image resizing.
        All bounding boxes below this threshold will be dropped.
        Helps in dropping bounding boxes outside of the image.
        Default : None or image_size[0]
    **max_bbox_y** : integer, optional
        Specifies the minimum y2 value for bounding boxes after image resizing.
        All bounding boxes below this threshold will be dropped.
        Helps in dropping bounding boxes outside of the image.
        Default : None or image_size[1]

This will help in two cases:

1. Reading too small bounding boxes that will later result in training errors (e.g. if bbox widh or height equals 0)
2. Reading bounding boxes with coordinates outside of the image (which also can lead to errors)

I also included a testcase in test_utils.py.