### PR TITLE
Add documentation for action keyword arguments

### DIFF
--- a/dlpy/audio.py
+++ b/dlpy/audio.py
@@ -327,7 +327,8 @@ class AudioTable(CASTable):
             Specifies whether shuffle the generated CAS table randomly.
             Default: True
         kwargs : keyword-arguments, optional
-            Additional parameter for feature extraction.
+            Additional parameter for feature extraction. For details, see the documentation for
+            `audio.computeFeatures <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casactml&docsetTarget=cas-audio-computefeatures.htm>`_.
 
         Returns
         -------

--- a/dlpy/images.py
+++ b/dlpy/images.py
@@ -221,8 +221,9 @@ class ImageTable(CASTable):
             Specifies the extra columns in the image table.
         caslib : string, optional
             The name of the caslib containing the images.
-        **kwargs : keyword arguments, optional
-            Additional keyword arguments to the `image.loadimages` action
+        kwargs : keyword arguments, optional
+            Additional keyword arguments to the `image.loadimages` action. For details, see
+            `the loadimages action <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casactml&docsetTarget=cas-image-loadimages.htm>`_
 
         Returns
         -------
@@ -321,6 +322,9 @@ class ImageTable(CASTable):
         ----------
         path : string
             Specifies the directory on the server to save the images
+        kwargs : keyword arguments, optional
+            Specifies additional arguments for the save action. For more details, see
+            `table.save <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=caspg&docsetTarget=cas-table-save.htm>`_
 
         '''
 

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -727,7 +727,8 @@ class Model(Network):
             response of the deep learning model.
             Default : '_label_'
         **kwargs : keyword arguments, optional
-            Specifies the optional arguments for the dltune action.
+            Specifies the optional arguments for the dltune action. For more details, see
+            `deepLearn.dlTune <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dltune.htm>`_
 
         Returns
         ----------
@@ -2009,7 +2010,8 @@ class Model(Network):
         image_id : list or int, optional
             Filters data using '_id_' column
         **kwargs : keyword arguments, optional
-            Specifies the optional arguments for the dlScore action.
+            Specifies the optional arguments for the dlScore action. For more details, see
+            `deepLearn.dlScore <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlscore.htm>`_
 
         """
         from .images import ImageTable
@@ -2070,8 +2072,9 @@ class Model(Network):
             Specifies the name of the layer that is extracted
         target : string, optional
             Specifies the name of the column including the response variable
-        **kwargs : keyword arguments, optional
-            Specifies the optional arguments for the dlScore action.
+         **kwargs : keyword arguments, optional
+            Specifies the optional arguments for the dlScore action. For more details, see
+            `deepLearn.dlScore <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlscore.htm>`_
 
         Returns
         -------
@@ -2137,7 +2140,8 @@ class Model(Network):
             Maximum number of images to display. Heatmap takes a significant amount
             of time to run so a max of 5 is default.
         **kwargs : keyword arguments, optional
-            Specifies the optional arguments for the dlScore action.
+            Specifies the optional arguments for the dlScore action. For more details, see
+            `deepLearn.dlScore <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlscore.htm>`
 
         Notes
         -----

--- a/dlpy/model.py
+++ b/dlpy/model.py
@@ -2072,7 +2072,7 @@ class Model(Network):
             Specifies the name of the layer that is extracted
         target : string, optional
             Specifies the name of the column including the response variable
-         **kwargs : keyword arguments, optional
+        **kwargs : keyword arguments, optional
             Specifies the optional arguments for the dlScore action. For more details, see
             `deepLearn.dlScore <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlscore.htm>`_
 
@@ -2141,7 +2141,7 @@ class Model(Network):
             of time to run so a max of 5 is default.
         **kwargs : keyword arguments, optional
             Specifies the optional arguments for the dlScore action. For more details, see
-            `deepLearn.dlScore <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlscore.htm>`
+            `deepLearn.dlScore <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlscore.htm>`_
 
         Notes
         -----

--- a/dlpy/network.py
+++ b/dlpy/network.py
@@ -1503,6 +1503,9 @@ class Network(Layer):
         layers : string list, optional
              Specifies the names of the layers to include in the output astore scoring results. This can be used to
              extract the features for given layers.
+        kwargs : keyword arguments, optional
+            Specifies additional keyword arguments for the dlExportModel action. For details, see
+            `deepLearn.dlExportModel <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casdlpg&docsetTarget=cas-deeplearn-dlexportmodel.htm>`_
         """
         self.conn.loadactionset('astore', _messagelevel='error')
 

--- a/dlpy/splitting.py
+++ b/dlpy/splitting.py
@@ -52,9 +52,10 @@ def two_way_split(tbl, test_rate=20, stratify=True, im_table=True, stratify_by='
         Specifies the output table name for the test set
     columns : list of column names
         Specifies the list of columns to be copied over to the resulting tables.
-    **kwargs : keyword arguments, optional
-        Additional keyword arguments to the `sample.stratified` or
-        'sample.src' actions
+    kwargs : keyword arguments, optional
+        Additional keyword arguments to the sample.stratified or
+        sample.src actions. For details see `sample.stratifed <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casactstat&docsetTarget=cas-sampling-stratified.htm>`_ and
+        `sample.srs <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casactstat&docsetTarget=cas-sampling-srs.htm>`_
 
     Returns
     -------
@@ -157,10 +158,10 @@ def three_way_split(tbl, valid_rate=20, test_rate=20, stratify=True, im_table=Tr
         Specifies the output table name for the validation set
     test_name : string
         Specifies the output table name for the test set
-    **kwargs : keyword arguments, optional
-        Additional keyword arguments to the `sample.stratified` or
-        'sample.srs' actions
-
+    kwargs : keyword arguments, optional
+        Additional keyword arguments to the sample.stratified or
+        sample.src actions. For details see `sample.stratifed <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casactstat&docsetTarget=cas-sampling-stratified.htm>`_ and
+        `sample.srs <https://documentation.sas.com/?cdcId=pgmsascdc&cdcVersion=default&docsetId=casactstat&docsetTarget=cas-sampling-srs.htm>`_
     Returns
     -------
     ( train CASTable, valid CASTable, test CASTable )


### PR DESCRIPTION
This commit adds to the docstrings of functions that use keyword arguments to pass options to CAS actions. In each docstring, I added a link to the the corresponding CAS documentation. The link points to the "default" documentation which is generally the most current LTS release. 

If you want to see a preview, I updated the HTML files in my gh-pages branch. They should be hosted at https://kybowm.github.io/python-dlpy but I don't see the changes yet even though I can confirm they are in my fork. Hopefully it's just taking the GitHub Pages server a while to refresh the content.

Let me know if you have any questions or concerns.