### PR TITLE
updated collections to collections.abc

### DIFF
--- a/dlpy/layers.py
+++ b/dlpy/layers.py
@@ -26,7 +26,7 @@ from . import __dev__
 import warnings
 import collections
 from copy import deepcopy
-from collections import Iterable
+from collections.abc import Iterable
 
 PALETTES = dict(
     original={

--- a/dlpy/utils.py
+++ b/dlpy/utils.py
@@ -3211,7 +3211,7 @@ def query_layer_parm(conn, layer_type, parm_name):
                     
     return parm_valid
 
-class DLPyDict(collections.MutableMapping):
+class DLPyDict(collections.abc.MutableMapping):
     """ Dictionary that applies an arbitrary key-altering function before accessing the keys """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
The `collections.abc` module was created in Python 3.3 and certain classes were moved from `collections` to `collections.abc`, including `MutableMapping` and `Iterable`.  As of Python 3.10, those classes are **only** available through `collections.abc` which causes dlpy to fail to import on Python >= 3.10.